### PR TITLE
Show one-time click prompt above gub image

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,21 @@
   <link rel="icon" href="favicon.ico" type="image/x-icon" />
   <style>
     body { margin:0; overflow:hidden; background:#111; position:relative; height:100vh; width:100vw; }
-    #main-gub { max-height:90vh; max-width:90vw; position:absolute; top:50%; left:50%; transform:translate(-50%,-50%); z-index:1; }
+    #gub-wrapper { position:absolute; top:50%; left:50%; transform:translate(-50%,-50%); z-index:1; }
+    #main-gub { max-height:90vh; max-width:90vw; display:block; }
+    #clickMe {
+      position:absolute;
+      top:0;
+      left:50%;
+      transform:translate(-50%, -100%);
+      color:#fff;
+      font-family:sans-serif;
+      font-weight:bold;
+      font-size:3rem;
+      pointer-events:none;
+      display:none;
+      white-space:nowrap;
+    }
 
     
     #btnRow { position:absolute; top:10px; left:10px; display:flex; gap:5px; z-index:9999; }
@@ -245,7 +259,10 @@
   </form>
 </div>
   <div id="twitchPlayer"></div>
-  <img id="main-gub" src="gub_wicked.png" alt="wickeding gub" />
+  <div id="gub-wrapper">
+    <img id="main-gub" src="gub_wicked.png" alt="wickeding gub" />
+    <div id="clickMe">click me</div>
+  </div>
   <canvas id="visualizer"></canvas>
   <script>
   window.addEventListener('DOMContentLoaded', () => {
@@ -559,9 +576,15 @@ function scheduleNextGolden(initial = false) {
       }
       // main gub handler
 const mainGub = document.getElementById('main-gub');
+const clickMe = document.getElementById('clickMe');
+if (!sessionStorage.getItem('gubClicked')) {
+  clickMe.style.display = 'block';
+}
 let popTimeout;
 
       mainGub.addEventListener('click', () => {
+        clickMe.style.display = 'none';
+        sessionStorage.setItem('gubClicked', 'true');
         sessionCount++;
         globalCount++;
         renderCounter();


### PR DESCRIPTION
## Summary
- Add "click me" prompt above main gub and hide it after click
- Remember clicks via sessionStorage so prompt shows once per session
- Enlarge prompt text and remove background box

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890234eae148323adbba99d7276c4c0