### PR TITLE
Ensure UI elements overlay floaters

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,13 +14,13 @@
   <link rel="icon" href="favicon.ico" type="image/x-icon" />
   <style>
     body { margin:0; overflow:hidden; background:#111; position:relative; height:100vh; width:100vw; }
-    #gub-wrapper { position:absolute; top:50%; left:50%; transform:translate(-50%,-50%); z-index:1; }
+    #gub-wrapper { position:absolute; top:50%; left:50%; transform:translate(-50%,-50%); }
     #main-gub { max-height:90vh; max-width:90vw; display:block; transform-origin:center; }
     #clickMe {
       position:absolute;
-      top:0;
+      top:200px;
       left:50%;
-      transform:translate(-50%, -100%);
+      transform:translateX(-50%);
       color:#fff;
       font-family:sans-serif;
       font-weight:bold;
@@ -28,6 +28,7 @@
       pointer-events:none;
       display:none;
       white-space:nowrap;
+      z-index:10001;
     }
 
     
@@ -69,7 +70,7 @@
   position: absolute;
   top: 40px;
   right: 10px;
-  z-index: 10000;
+  z-index: 10001;
   background: #fff;
   color: #000;
   border: none;
@@ -91,7 +92,7 @@
   color: #fff;
   padding: 8px;
   border-radius: 6px;
-  z-index: 10000;
+  z-index: 10001;
 }
   #shopPanel h4 {
   font-size: 2rem;    /* makes it roughly 32px tall */
@@ -261,8 +262,8 @@
   <div id="twitchPlayer"></div>
    <div id="gub-wrapper">
     <img id="main-gub" src="gub_wicked.png" alt="wickeding gub" />
-    <div id="clickMe">click me</div>
   </div>
+  <div id="clickMe">click me</div>
   <canvas id="visualizer"></canvas>
   <script>
   window.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- Move "click me" prompt below the top of the page and ensure it overlays animated floaters
- Raise z-index of Shop button and panel so they stay above all floaters

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68902873cd2483239f2a0a5a24e928b6