### PR TITLE
Add click-based +1 popup to main gub

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,13 +44,29 @@
     .floater img  { width:100%; height:100%; object-fit:contain; }
 
     @keyframes rainbow {0%{color:red;}20%{color:orange;}40%{color:yellow;}60%{color:green;}80%{color:blue;}100%{color:violet;}}
-    @keyframes pop {
+  @keyframes pop {
   0%   { transform: scale(1); }
   50%  { transform: scale(1.1); }
   100% { transform: scale(1); }
 }
 .pop-effect {
   animation: pop 0.15s ease-out both;
+}
+
+.plus-one {
+  position: absolute;
+  color: #fff;
+  font-family: sans-serif;
+  font-weight: bold;
+  font-size: 2rem;
+  pointer-events: none;
+  z-index: 10002;
+  transform: translate(-50%, -50%);
+  animation: fadeUp 1s ease-out forwards;
+}
+@keyframes fadeUp {
+  from { opacity: 1; transform: translate(-50%, -50%) translateY(0); }
+  to   { opacity: 0; transform: translate(-50%, -50%) translateY(-20px); }
 }
 
 #main-gub {
@@ -583,7 +599,7 @@ if (!sessionStorage.getItem('gubClicked')) {
 }
 let popTimeout;
 
-      mainGub.addEventListener('click', () => {
+      mainGub.addEventListener('click', (e) => {
         clickMe.style.display = 'none';
         sessionStorage.setItem('gubClicked', 'true');
         sessionCount++;
@@ -591,6 +607,14 @@ let popTimeout;
         renderCounter();
         db.ref(`leaderboard/${username}`).set({ score: globalCount });
         updateLeaderboard();
+
+        const plusOne = document.createElement('div');
+        plusOne.textContent = '+1';
+        plusOne.className = 'plus-one';
+        plusOne.style.left = `${e.clientX}px`;
+        plusOne.style.top = `${e.clientY}px`;
+        document.body.appendChild(plusOne);
+        setTimeout(() => plusOne.remove(), 1000);
 
         mainGub.classList.remove('pop-effect');
         void mainGub.offsetWidth;


### PR DESCRIPTION
## Summary
- Animate +1 text at the cursor when main gub is clicked, fading upward and removing after a second
- Style +1 popup with new `fadeUp` animation

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68903ba098188323a07898cbfa7084dc