### PR TITLE
Restrict leaderboard writes and add increment Cloud Function

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -1,0 +1,26 @@
+{
+  "rules": {
+    "presence": {
+      ".read": true,
+      ".write": true
+    },
+    "leaderboard": {
+      ".read": true,
+      ".indexOn": ["score"],
+      "$uid": {
+        ".write": "auth != null && $uid === auth.uid"
+      }
+    },
+    "chat": {
+      ".read": true,
+      ".write": "auth != null",
+      ".indexOn": ["ts"]
+    },
+    "shop": {
+      "$uid": {
+        ".read": true,
+        ".write": "auth != null && $uid === auth.uid"
+      }
+    }
+  }
+}

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,8 @@
+{
+  "functions": {
+    "source": "functions"
+  },
+  "database": {
+    "rules": "database.rules.json"
+  }
+}

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,35 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+
+admin.initializeApp();
+
+exports.incrementScore = functions.https.onCall(async (data, context) => {
+  const uid = context.auth && context.auth.uid;
+  if (!uid) {
+    throw new functions.https.HttpsError('unauthenticated', 'Authentication required');
+  }
+
+  const amount = Number(data.amount || 0);
+  if (!Number.isFinite(amount)) {
+    throw new functions.https.HttpsError('invalid-argument', 'Amount must be a number');
+  }
+
+  const presenceRef = admin.database().ref(`/presence/${uid}`);
+  const presenceSnap = await presenceRef.once('value');
+  if (!presenceSnap.exists()) {
+    throw new functions.https.HttpsError('failed-precondition', 'User not online');
+  }
+
+  const scoreRef = admin.database().ref(`/leaderboard/${uid}/score`);
+  const snap = await scoreRef.once('value');
+  if (!snap.exists()) {
+    throw new functions.https.HttpsError('failed-precondition', 'Score entry does not exist');
+  }
+
+  await scoreRef.transaction(current => {
+    return (current || 0) + amount;
+  });
+
+  const newSnap = await scoreRef.once('value');
+  return { score: newSnap.val() };
+});

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "gub-gub-functions",
+  "engines": {
+    "node": "18"
+  },
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.0"
+  }
+}

--- a/index.html
+++ b/index.html
@@ -214,6 +214,7 @@
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-database-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-functions-compat.js"></script>
 </head>
 <body>
   <div id="btnRow">
@@ -373,20 +374,21 @@ const firebaseConfig = {
 firebase.auth().signInAnonymously().then(() => {
   const db  = firebase.database();
   const uid = firebase.auth().currentUser.uid;
+  const functions = firebase.functions();
 
         // ─── Presence Setup ───────────────────────────────────────────────
   const presenceRef   = db.ref('.info/connected');
-  const userOnlineRef = db.ref('presence/' + username);
+  const userOnlineRef = db.ref('presence/' + uid);
 
   presenceRef.on('value', snap => {
     if (snap.val() === true) {
-      userOnlineRef.set(true);
+      userOnlineRef.set(username);
       userOnlineRef.onDisconnect().remove();
     }
   });
 
   db.ref('presence').on('value', snap => {
-    const users = snap.val() ? Object.keys(snap.val()) : [];
+    const users = snap.val() ? Object.values(snap.val()) : [];
     document.getElementById('online-users').textContent =
       'Online: ' + users.join(', ');
   });
@@ -395,19 +397,20 @@ firebase.auth().signInAnonymously().then(() => {
       let sessionCount = 0, globalCount = 0;
 
       // Load or initialize user's score
-const userRef = db.ref(`leaderboard/${username}/score`);
+const userRef = db.ref(`leaderboard/${uid}/score`);
 userRef.once('value').then(snap => {
   globalCount = snap.val() || 0;
 
   renderCounter();
-  // Ensure entry exists
-  db.ref(`leaderboard/${username}`).set({ score: globalCount });
-  
+  // Ensure entry exists with username
+  db.ref(`leaderboard/${uid}`).update({ score: globalCount, name: username });
+
 // Real-time leaderboard updates
 db.ref('leaderboard').on('value', snap => {
   const list = [];
   snap.forEach(child => {
-    list.push({ user: child.key, score: child.val().score || 0 });
+    const val = child.val();
+    list.push({ user: val.name || child.key, score: val.score || 0 });
   });
   list.sort((a, b) => b.score - a.score);
   document.getElementById('leaderboard').innerHTML =
@@ -493,11 +496,13 @@ function updateLeaderboard() {
         el.style.pointerEvents = 'auto';
         document.body.appendChild(el);
         el.addEventListener('click', () => {
-          sessionCount +=15;
-          globalCount +=15;
-          renderCounter();
-          db.ref(`leaderboard/${username}`).set({ score: globalCount });
-          updateLeaderboard();
+          sessionCount += 15;
+          functions.httpsCallable('incrementScore')({ amount: 15 })
+            .then(res => {
+              globalCount = res.data.score;
+              renderCounter();
+              updateLeaderboard();
+            });
           el.remove();
           scheduleNextGolden();
         });
@@ -551,10 +556,12 @@ function spawnSpecialGub() {
   // 5. click handler awards +5
   container.addEventListener('click', () => {
     sessionCount += 50;
-    globalCount  += 50;
-    renderCounter();
-    db.ref(`leaderboard/${username}`).set({ score: globalCount });
-    updateLeaderboard();
+    functions.httpsCallable('incrementScore')({ amount: 50 })
+      .then(res => {
+        globalCount = res.data.score;
+        renderCounter();
+        updateLeaderboard();
+      });
     container.remove();
     scheduleNextGolden();
   });
@@ -587,10 +594,12 @@ let popTimeout;
         clickMe.style.display = 'none';
         sessionStorage.setItem('gubClicked', 'true');
         sessionCount++;
-        globalCount++;
-        renderCounter();
-        db.ref(`leaderboard/${username}`).set({ score: globalCount });
-        updateLeaderboard();
+        functions.httpsCallable('incrementScore')({ amount: 1 })
+          .then(res => {
+            globalCount = res.data.score;
+            renderCounter();
+            updateLeaderboard();
+          });
 
         mainGub.classList.remove('pop-effect');
         void mainGub.offsetWidth;
@@ -620,9 +629,11 @@ let popTimeout;
         if (perMinute > 0) {
           const interval = 60_000 / perMinute;
           passiveTimers[item.id] = setInterval(() => {
-            globalCount++;
-            renderCounter();
-            db.ref(`leaderboard/${username}`).set({ score: Math.floor(globalCount) });
+            functions.httpsCallable('incrementScore')({ amount: 1 })
+              .then(res => {
+                globalCount = res.data.score;
+                renderCounter();
+              });
           }, interval);
         }
       });
@@ -650,13 +661,15 @@ shopItems.forEach(item => {
 
   div.querySelector(`#buy-${item.id}`).addEventListener('click', () => {
     if (globalCount >= item.cost) {
-      globalCount -= item.cost;
       owned[item.id] += 1;
       document.getElementById(`owned-${item.id}`).textContent = owned[item.id];
-      renderCounter();
+      functions.httpsCallable('incrementScore')({ amount: -item.cost })
+        .then(res => {
+          globalCount = res.data.score;
+          renderCounter();
+          updatePassiveIncome();
+        });
       db.ref(`shop/${uid}/${item.id}`).set(owned[item.id]);
-      db.ref(`leaderboard/${username}`).set({ score: Math.floor(globalCount) });
-      updatePassiveIncome();
     }
   });
 });


### PR DESCRIPTION
## Summary
- Lock down realtime database so only the authenticated user can write to their own leaderboard entry
- Add `incrementScore` Cloud Function to validate user presence before applying atomic score updates
- Track presence by UID on the client and route score changes through the callable function

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm --prefix functions test` *(fails: Missing script "test")*
- `npm --prefix functions install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/firebase-admin)*

------
https://chatgpt.com/codex/tasks/task_e_68902e12a2ec8323bcbbebf488d5f59a