### PR TITLE
Fix overlapping leaderboard and chat

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,21 +129,27 @@
   pointer-events: none;
 }
     
-#online-users {
+#bottom-ui {
   position: absolute;
   bottom: 10px;
-  left: 499px;
+  left: 10px;
+  display: flex;
+  gap: 10px;
+  align-items: flex-end;
+  z-index: 10000;
+}
+
+#online-users {
   background: rgba(0,0,0,0.6);
   color: #fff;
   padding: 6px 10px;
   border-radius: 6px;
   font-family: sans-serif;
   font-size: 14px;
-  z-index: 10001;
 }
     #twitchPlayer  { position:absolute; top:50px; right:10px; width:500px; height:300px; z-index:9000; display:none; box-shadow:0 0 8px #000; border-radius:8px; overflow:hidden; }
     #golden-counter { position:absolute; top:10px; right:10px; z-index:10000; color:white; font-family:sans-serif; font-size:20px; font-weight:bold; }
-    #leaderboard { position:absolute; bottom:10px; left:10px; background:rgba(0,0,0,0.6); color:#fff; padding:10px; border-radius:6px; font-family:sans-serif; z-index:10000; }
+    #leaderboard { background:rgba(0,0,0,0.6); color:#fff; padding:10px; border-radius:6px; font-family:sans-serif; }
 #discordWrapper {
   position: absolute;
   bottom: 10px;
@@ -176,9 +182,6 @@
 }
 
     #chat {
-  position: absolute;
-  bottom: 10px;
-  left: 196px;         
   width: 300px;
   max-height: 150px;   /* match leaderboard height or adjust */
   border-radius: 8px;
@@ -187,7 +190,6 @@
   font-family: sans-serif;
   padding: 8px;
   box-sizing: border-box;
-  z-index: 10000;
   display: flex;
   flex-direction: column;
 }
@@ -264,17 +266,19 @@
 />
   </div>
   <div id="golden-counter">Gubs: 0</div>
-  <div id="online-users">
-    Online: …
+  <div id="bottom-ui">
+    <div id="leaderboard"><strong>Leaderboard</strong><br>Loading…</div>
+    <div id="chat">
+      <div id="messages"></div>
+      <form id="chatForm">
+        <input id="chatInput" type="text" placeholder="Type a message…" autocomplete="off" />
+        <button type="submit">Send</button>
+      </form>
+    </div>
+    <div id="online-users">
+      Online: …
+    </div>
   </div>
-  <div id="leaderboard"><strong>Leaderboard</strong><br>Loading…</div>
-  <div id="chat">
-  <div id="messages"></div>
-  <form id="chatForm">
-    <input id="chatInput" type="text" placeholder="Type a message…" autocomplete="off" />
-    <button type="submit">Send</button>
-  </form>
-</div>
   <div id="twitchPlayer"></div>
    <div id="gub-wrapper">
     <img id="main-gub" src="gub_wicked.png" alt="wickeding gub" />


### PR DESCRIPTION
## Summary
- Wrap leaderboard, chat and online user counter in a flex container
- Remove fixed left offsets so chat moves as leaderboard width changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68905c8d7c9c83238962c5e669593007