### PR TITLE
Drop decimals for small counts

### DIFF
--- a/index.html
+++ b/index.html
@@ -442,10 +442,10 @@ firebase.auth().signInAnonymously().then(() => {
       }, 1000);
 
       function abbreviateNumber(num){
-        if(num < 1000) return num.toFixed(2);
+        if (num < 1000) return Math.floor(num).toString();
         const units = ['', 'k', 'm', 'b', 't', 'quad', 'quin', 'sext', 'sept', 'octi', 'noni', 'deci'];
         let idx = Math.floor(Math.log10(num) / 3);
-        if(idx >= units.length) idx = units.length - 1;
+        if (idx >= units.length) idx = units.length - 1;
         const scaled = num / Math.pow(1000, idx);
         return scaled.toFixed(2) + units[idx];
       }


### PR DESCRIPTION
## Summary
- Avoid showing `.00` for values below 1000 in number abbreviations
- Retain two decimal precision when abbreviating thousands and above

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689066e81130832398f01885f79b4dc1