### PR TITLE
Fix leaderboard read access in Firebase rules

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -1,8 +1,8 @@
 {
   "rules": {
     "leaderboard": {
+      ".read": true,
       "$uid": {
-        ".read": true,
         ".write": "auth != null && auth.uid === $uid",
         "username": {
           ".validate": "newData.isString() && newData.val().matches(/^[A-Za-z0-9_]{3,20}$/)"


### PR DESCRIPTION
## Summary
- Allow public read access at the `leaderboard` root path so clients can load the full leaderboard

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689101fdce0c8323a9ad08d144207dc3