### PR TITLE
Allow presence list reads

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -13,8 +13,8 @@
       }
     },
     "presence": {
+      ".read": true,
       "$uid": {
-        ".read": true,
         ".write": "auth != null && auth.uid === $uid && newData.isString() && newData.val().matches(/^[A-Za-z0-9_]{3,20}$/)"
       }
     },


### PR DESCRIPTION
## Summary
- permit reading the entire presence path so clients can see others online

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689105ae4f60832393d9281d0ff8c620