### PR TITLE
Handle missing config version and relax presence writes

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -19,7 +19,8 @@
     "presence": {
       ".read": true,
       "$uid": {
-        ".write": "auth != null && auth.uid === $uid && newData.isString() && newData.val().matches(/^[A-Za-z0-9_]{3,20}$/)"
+        ".write": "auth != null && auth.uid === $uid",
+        ".validate": "newData.val() == null || (newData.isString() && newData.val().matches(/^[A-Za-z0-9_]{3,20}$/))"
       }
     },
     "chat": {

--- a/index.html
+++ b/index.html
@@ -449,7 +449,8 @@ firebase.auth().signInAnonymously().then(() => {
   const versionRef = db.ref('config/version');
   versionRef.on('value', snap => {
     const serverVersion = snap.val();
-    if (serverVersion !== CLIENT_VERSION) {
+    // Only force a reload when the server has a version and it differs from the client
+    if (serverVersion && serverVersion !== CLIENT_VERSION) {
       const warn = document.createElement('div');
       warn.textContent = 'Site updated - reloading...';
       warn.style.cssText = 'position:fixed;top:0;left:0;width:100%;background:red;color:white;text-align:center;font-size:24px;padding:20px;z-index:100000;';


### PR DESCRIPTION
## Summary
- Avoid reload loop by checking for server config version before forcing reload
- Permit presence removal while keeping username validation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68911482f0188323878bfc9822007638