### PR TITLE
feat: bump version and isolate new leaderboard

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -6,8 +6,12 @@
     },
     "leaderboard_v2": {
       ".read": true,
+      ".write": false
+    },
+    "leaderboard_v3": {
+      ".read": true,
       "$uid": {
-        ".write": "auth != null && (auth.uid === $uid || root.child('leaderboard_v2').child(auth.uid).child('username').val() === 'figgy')",
+        ".write": "auth != null && (auth.uid === $uid || root.child('leaderboard_v3').child(auth.uid).child('username').val() === 'figgy')",
         "username": {
           ".validate": "newData.isString() && newData.val().matches(/^[A-Za-z0-9_]{3,20}$/)"
         },

--- a/firebase.json
+++ b/firebase.json
@@ -4,7 +4,7 @@
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "headers": [
       {
-        "source": "/index.html",
+        "source": "**",
         "headers": [
           {
             "key": "Cache-Control",

--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@
   <canvas id="visualizer"></canvas>
   <script>
   window.addEventListener('DOMContentLoaded', () => {
-const CLIENT_VERSION = '0.1.2';
+const CLIENT_VERSION = '0.1.3';
 document.getElementById('versionNumber').textContent = `v${CLIENT_VERSION}`;
 const isMobile = window.innerWidth < 768;
 const NUM_FLOATERS = isMobile ? 5 : 20;
@@ -503,7 +503,7 @@ firebase.auth().signInAnonymously().then(() => {
         if (scoreDirty && currentScore !== lastSentScore) {
           scoreDirty = false;
           lastSentScore = currentScore;
-          db.ref(`leaderboard_v2/${uid}`).set({ username, score: currentScore });
+          db.ref(`leaderboard_v3/${uid}`).set({ username, score: currentScore });
         }
       }, 1000);
 
@@ -517,13 +517,13 @@ firebase.auth().signInAnonymously().then(() => {
       }
 
       // Load or initialize user's score, migrating any legacy username entries
-      const userRef = db.ref(`leaderboard_v2/${uid}/score`);
+      const userRef = db.ref(`leaderboard_v3/${uid}/score`);
       userRef.once('value').then(async snap => {
         if (snap.exists()) {
           globalCount = snap.val() || 0;
         } else {
           // Try to migrate from old username-based key
-          const legacyRef = db.ref(`leaderboard_v2/${username}/score`);
+          const legacyRef = db.ref(`leaderboard_v3/${username}/score`);
           const legacySnap = await legacyRef.once('value');
           globalCount = legacySnap.val() || 0;
           if (legacySnap.exists()) {
@@ -532,7 +532,7 @@ firebase.auth().signInAnonymously().then(() => {
         }
         displayedCount = globalCount;
         renderCounter();
-        db.ref(`leaderboard_v2/${uid}`).set({ username, score: globalCount });
+        db.ref(`leaderboard_v3/${uid}`).set({ username, score: globalCount });
         lastSentScore = Math.floor(globalCount);
 
         // Keep local score in sync with external/manual updates
@@ -547,7 +547,7 @@ firebase.auth().signInAnonymously().then(() => {
         });
 
 // Real-time leaderboard updates (top 10 only)
-  db.ref('leaderboard_v2')
+  db.ref('leaderboard_v3')
     .orderByChild('score')
     .limitToLast(10)
     .on('value', snap => {
@@ -881,7 +881,7 @@ adminUpdate.addEventListener('click', () => {
   const target = sanitizeUsername(adminUser.value);
   const score  = parseInt(adminScore.value, 10);
   if (!target || isNaN(score)) return;
-  db.ref('leaderboard_v2').orderByChild('username').equalTo(target).once('value').then(snap => {
+  db.ref('leaderboard_v3').orderByChild('username').equalTo(target).once('value').then(snap => {
     snap.forEach(child => {
       child.ref.update({ score });
     });
@@ -891,7 +891,7 @@ adminUpdate.addEventListener('click', () => {
 adminDelete.addEventListener('click', () => {
   const target = sanitizeUsername(adminUser.value);
   if (!target) return;
-  db.ref('leaderboard_v2').orderByChild('username').equalTo(target).once('value').then(snap => {
+  db.ref('leaderboard_v3').orderByChild('username').equalTo(target).once('value').then(snap => {
     snap.forEach(child => child.ref.remove());
   });
 });
@@ -1169,7 +1169,7 @@ chaosBtn.addEventListener('click', () => {
     });
   </script>
   <div id="discordWrapper">
-    <span id="versionNumber">v0.1.2</span>
+    <span id="versionNumber">v0.1.3</span>
     <a id="discordBtn" href="https://discord.gg/nutpit" target="_blank" rel="noopener">Discord</a>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- bump client to v0.1.3 and reload if server version mismatches
- freeze old leaderboard and write scores to new `leaderboard_v3`
- send Cache-Control headers for all assets to avoid browser caching

## Testing
- `python -m json.tool firebase.json`
- `python -m json.tool database.rules.json`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689118267074832394e1a8bd0837cf1e