### PR TITLE
chore: disable writes to legacy shop

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -46,10 +46,7 @@
     "shop": {
       "$uid": {
         ".read": "auth != null && auth.uid === $uid",
-        ".write": "auth != null && auth.uid === $uid",
-        "$item": {
-          ".validate": "newData.isNumber() && newData.val() >= 0"
-        }
+        ".write": false
       }
     },
     "shop_v2": {


### PR DESCRIPTION
## Summary
- block writes to the legacy `shop` path in Firebase rules, leaving `shop_v2` as the writable store

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68911b760e288323bf54b4eeb474eac2