### PR TITLE
feat: add see feedback button

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,6 +245,11 @@
 }
 #feedbackModal button {
   margin-top: 6px;
+}
+#feedbackSee {
+  float: left;
+}
+#feedbackSubmit {
   float: right;
 }
 
@@ -1027,9 +1032,15 @@ shopRef.once('value').then(snapshot => {
   const feedbackModal = document.getElementById('feedbackModal');
   const feedbackInput = document.getElementById('feedbackInput');
   const feedbackSubmit = document.getElementById('feedbackSubmit');
+  const feedbackSee = document.getElementById('feedbackSee');
 
   feedbackBtn.addEventListener('click', () => {
     feedbackModal.style.display = feedbackModal.style.display === 'block' ? 'none' : 'block';
+  });
+
+  feedbackSee.addEventListener('click', () => {
+    window.open('feedback-list/', '_blank');
+    feedbackModal.style.display = 'none';
   });
 
   feedbackSubmit.addEventListener('click', () => {
@@ -1228,6 +1239,7 @@ chaosBtn.addEventListener('click', () => {
   </script>
   <div id="feedbackModal">
     <textarea id="feedbackInput" placeholder="Your suggestion"></textarea>
+    <button id="feedbackSee">See Feedback</button>
     <button id="feedbackSubmit">Send</button>
   </div>
   <div id="discordWrapper">


### PR DESCRIPTION
## Summary
- add a See Feedback button to the feedback modal linking to the feedback list
- style the feedback modal buttons so See Feedback sits left and Send right

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689135d0f1a48323a0b8990356bb8ea1