### PR TITLE
Highlight own @mentions and secure admin access

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -11,7 +11,7 @@
     "leaderboard_v3": {
       ".read": true,
       "$uid": {
-        ".write": "auth != null && (auth.uid === $uid || root.child('leaderboard_v3').child(auth.uid).child('username').val() === 'figgy')",
+        ".write": "auth != null && (auth.uid === $uid || root.child('admins').child(auth.uid).val() === true)",
         "username": {
           ".validate": "newData.isString() && newData.val().matches(/^[A-Za-z0-9_]{3,20}$/)"
         },
@@ -43,6 +43,12 @@
       },
       ".indexOn": ["ts"]
     },
+    "admins": {
+      "$uid": {
+        ".read": "auth != null && auth.uid === $uid",
+        ".write": "auth != null && (auth.uid === 'sGd1ZHR1nvMKKCw9A1O5bwtbFD23' || auth.uid === 'YHtvs4JyAtS3SUtNAUJuPMm3ac22' || root.child('admins').child(auth.uid).val() === true)"
+      }
+    },
     "shop": {
       "$uid": {
         ".read": "auth != null && auth.uid === $uid",
@@ -61,7 +67,7 @@
     "feedback": {
       ".read": true,
       "$id": {
-        ".write": "auth != null && (newData.hasChildren(['user','text','ts']) || (newData.val() == null && root.child('leaderboard_v3').child(auth.uid).child('username').val() == 'figgy'))",
+        ".write": "auth != null && (newData.hasChildren(['user','text','ts']) || (newData.val() == null && root.child('admins').child(auth.uid).val() === true))",
         "user": {
           ".validate": "newData.isString() && newData.val().matches(/^[A-Za-z0-9_]{3,20}$/)"
         },

--- a/feedback-list/index.html
+++ b/feedback-list/index.html
@@ -43,13 +43,22 @@
       function sanitizeUsername(name) {
         return (name || '').replace(/[^A-Za-z0-9_]/g, '').slice(0,20);
       }
-      const username = sanitizeUsername(localStorage.getItem('gubUser')) || 'Anon';
-      const isAdmin = ['figgy', 'harupi'].includes(username.toLowerCase());
-      const listEl = document.getElementById('list');
-      const feedbackRef = db.ref('feedback');
+        const username = sanitizeUsername(localStorage.getItem('gubUser')) || 'Anon';
+        const listEl = document.getElementById('list');
+        const feedbackRef = db.ref('feedback');
+        let isAdmin = false;
 
-      feedbackRef.on('child_added', snap => render(snap.key, snap.val()));
-      feedbackRef.on('child_changed', snap => render(snap.key, snap.val()));
+        const ADMIN_UIDS = ['sGd1ZHR1nvMKKCw9A1O5bwtbFD23', 'YHtvs4JyAtS3SUtNAUJuPMm3ac22'];
+        db.ref('admins/' + uid).once('value').then(snap => {
+          if (!snap.exists() && ADMIN_UIDS.includes(uid)) {
+            db.ref('admins/' + uid).set(true);
+            isAdmin = true;
+          } else {
+            isAdmin = !!snap.val();
+          }
+          feedbackRef.on('child_added', snap => render(snap.key, snap.val()));
+          feedbackRef.on('child_changed', snap => render(snap.key, snap.val()));
+        });
 
       function render(id, data) {
         let div = document.getElementById('fb-' + id);

--- a/index.html
+++ b/index.html
@@ -1022,11 +1022,16 @@ const adminUser     = document.getElementById('adminUsername');
 const adminScore    = document.getElementById('adminScore');
 const adminUpdate   = document.getElementById('adminUpdate');
 const adminDelete   = document.getElementById('adminDelete');
-const ADMINS        = ['figgy', 'harupi'];
 
-if (ADMINS.includes(username.toLowerCase())) {
-  adminBtn.style.display = 'block';
-}
+const ADMIN_UIDS = ['sGd1ZHR1nvMKKCw9A1O5bwtbFD23', 'YHtvs4JyAtS3SUtNAUJuPMm3ac22'];
+db.ref('admins/' + uid).once('value').then(snap => {
+  if (!snap.exists() && ADMIN_UIDS.includes(uid)) {
+    db.ref('admins/' + uid).set(true);
+    adminBtn.style.display = 'block';
+  } else if (snap.val()) {
+    adminBtn.style.display = 'block';
+  }
+});
 
 adminBtn.addEventListener('click', () => {
   adminPanel.style.display = adminPanel.style.display === 'block' ? 'none' : 'block';


### PR DESCRIPTION
## Summary
- Highlight your @username in chat so only you see it emphasized
- Move admin checks to Firebase UID-based `admins` list for safer access control
- Seed specified admin UIDs and permit them to manage the `admins` path

## Testing
- `python -m json.tool database.rules.json`


------
https://chatgpt.com/codex/tasks/task_e_6891477d04148323be5825be3923505b