### PR TITLE
Make shop panel scrollable when larger than screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,6 +118,8 @@
   padding: 8px;
   border-radius: 6px;
   z-index: 10001;
+  max-height: calc(100vh - 120px);
+  overflow-y: auto;
 }
   #shopPanel h4 {
   font-size: 2rem;    /* makes it roughly 32px tall */


### PR DESCRIPTION
## Summary
- allow shop panel to scroll when it exceeds viewport height

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68914c2df60c832392ed0e902e1e1bb3