### PR TITLE
Normalize usernames for chat highlighting

### DIFF
--- a/feedback-list/index.html
+++ b/feedback-list/index.html
@@ -41,7 +41,7 @@
       const db = firebase.database();
       const uid = firebase.auth().currentUser.uid;
       function sanitizeUsername(name) {
-        return (name || '').replace(/[^A-Za-z0-9_]/g, '').slice(0,20);
+        return (name || '').toLowerCase().replace(/[^a-z0-9_]/g, '').slice(0,20);
       }
         const username = sanitizeUsername(localStorage.getItem('gubUser')) || 'Anon';
         const listEl = document.getElementById('list');

--- a/index.html
+++ b/index.html
@@ -497,7 +497,7 @@ specialStyle.textContent = `
 document.head.appendChild(specialStyle);
     // Sanitize usernames (letters, numbers, underscore; max 20 chars)
     function sanitizeUsername(name) {
-      return (name || '').replace(/[^A-Za-z0-9_]/g, '').slice(0, 20);
+      return (name || '').toLowerCase().replace(/[^a-z0-9_]/g, '').slice(0, 20);
     }
 
     // 1. Prompt & sanitize username


### PR DESCRIPTION
## Summary
- Ensure usernames are stored and compared in lowercase so mentions highlight reliably
- Apply same username sanitization logic to feedback list

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891532f15848323954275fecfcfaa44