### PR TITLE
Add space before gub per second rate display

### DIFF
--- a/index.html
+++ b/index.html
@@ -407,7 +407,7 @@
 />
   </div>
   <div id="golden-counter">
-    <div id="gubTotal">Gubs: 0 (0gub/s)</div>
+    <div id="gubTotal">Gubs: 0 (0 gub/s)</div>
   </div>
   <div id="bottom-ui">
     <div id="leaderboard"><strong>Leaderboard</strong><br>Loading…</div>
@@ -987,7 +987,7 @@ function scheduleNextGolden() {
 
       function renderCounter() {
         const rate = abbreviateNumber(passiveRatePerSec * gubRateMultiplier);
-        gubTotalEl.textContent = 'Gubs: ' + abbreviateNumber(Math.floor(displayedCount)) + ' (' + rate + 'gub/s)';
+        gubTotalEl.textContent = 'Gubs: ' + abbreviateNumber(Math.floor(displayedCount)) + ' (' + rate + ' gub/s)';
       }
 
       function gainGubs(amount) {


### PR DESCRIPTION
## Summary
- ensure gub/s rate displays with a space after the number

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893a4c625148323a7d1cf8321bb8f42