### PR TITLE
Fix chat hitbox blocking gub when zoomed

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,6 +174,11 @@
   gap: 10px;
   align-items: flex-end;
   z-index: 10000;
+  pointer-events: none;
+}
+
+#bottom-ui > * {
+  pointer-events: auto;
 }
 
 #online-users {


### PR DESCRIPTION
## Summary
- prevent `#bottom-ui` container from intercepting clicks by disabling pointer events and re-enabling them on its children

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689403d93f488323bec9a658d967eb0f