### PR TITLE
Resume audio context on key press to restore mention sound

### DIFF
--- a/index.html
+++ b/index.html
@@ -484,6 +484,9 @@ chaosAudio.volume = isNaN(stored) ? 0.5 : stored;
     window.addEventListener('click', () => {
       if (audioCtx.state === 'suspended') audioCtx.resume();
       }, { once: true });
+    window.addEventListener('keydown', () => {
+      if (audioCtx.state === 'suspended') audioCtx.resume();
+      }, { once: true });
 
     const bufferLength = analyser.frequencyBinCount;
     const dataArray    = new Uint8Array(bufferLength);


### PR DESCRIPTION
## Summary
- Resume the audio context when a key is pressed so mention notification sounds work after typing

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894099a7edc8323b47819f7e57eb811