### PR TITLE
harden external resources

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -9,6 +9,22 @@
           {
             "key": "Cache-Control",
             "value": "no-cache, no-store, must-revalidate"
+          },
+          {
+            "key": "Content-Security-Policy",
+            "value": "default-src 'self'; script-src 'self' https://embed.twitch.tv https://www.gstatic.com; connect-src 'self' https://7tv.io https://*.firebaseio.com https://identitytoolkit.googleapis.com; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; frame-src https://player.twitch.tv"
+          },
+          {
+            "key": "X-Content-Type-Options",
+            "value": "nosniff"
+          },
+          {
+            "key": "X-Frame-Options",
+            "value": "DENY"
+          },
+          {
+            "key": "Referrer-Policy",
+            "value": "strict-origin-when-cross-origin"
           }
         ]
       }

--- a/index.html
+++ b/index.html
@@ -22,10 +22,30 @@
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
     <link rel="stylesheet" href="style.css" />
-    <script src="https://embed.twitch.tv/embed/v1.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-database-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+    <script
+      src="https://embed.twitch.tv/embed/v1.js"
+      integrity="sha384-RZ28VvtH8iX008KoSoTGq9yUWWmruBCja+k14R2Q3EI55YSPQMv+lMsbVxJojPWh"
+      crossorigin="anonymous"
+      defer
+    ></script>
+    <script
+      src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"
+      integrity="sha384-HLJUgAQ2oo6rdMC4QW+Oz2qQfPOtu/lzncKG4sZiq8+2W9uOa3K0b3UGpckKqv7H"
+      crossorigin="anonymous"
+      defer
+    ></script>
+    <script
+      src="https://www.gstatic.com/firebasejs/9.22.2/firebase-database-compat.js"
+      integrity="sha384-f6/UpzjTjIXASlp20cArQsaRh1EvHVJd5kegy/gYR9W2D0a32TnEqUEiW4Zm/5O0"
+      crossorigin="anonymous"
+      defer
+    ></script>
+    <script
+      src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"
+      integrity="sha384-+/4lqMnmLqwbdHXshvGDmBTeWlNoPRdjXi4ZsiBj10EhQXaTBe3RF5JZktdSjug6"
+      crossorigin="anonymous"
+      defer
+    ></script>
   </head>
   <body>
     <div id="btnRow">

--- a/script.js
+++ b/script.js
@@ -409,6 +409,9 @@ window.addEventListener("DOMContentLoaded", () => {
             emoteMap[e.name] = url;
             emoteMap[e.name.toLowerCase()] = url;
           });
+        })
+        .catch((err) => {
+          console.error("Failed to load 7TV emote set", err);
         });
 
       // Only allow emotes from Harupi's set; no global fallback


### PR DESCRIPTION
## Summary
- add subresource integrity and defer to third-party scripts
- harden 7TV emote fetch with error handling
- add security headers for CSP, X-Content-Type-Options, X-Frame-Options, and Referrer-Policy

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894beb95d2c832383822181029aab3c