### PR TITLE
Add preconnect hints for Twitch and Firebase scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,8 @@
     <meta http-equiv="Expires" content="0" />
     <link rel="stylesheet" href="styles/base.css" />
     <link rel="stylesheet" href="styles/chat.css" />
+    <link rel="preconnect" href="https://embed.twitch.tv" crossorigin />
+    <link rel="preconnect" href="https://www.gstatic.com" crossorigin />
     <script
       src="https://embed.twitch.tv/embed/v1.js"
       integrity="sha384-RZ28VvtH8iX008KoSoTGq9yUWWmruBCja+k14R2Q3EI55YSPQMv+lMsbVxJojPWh"


### PR DESCRIPTION
## Summary
- add preconnect hints for Twitch and gstatic hosts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894c9769cfc8323937c6ce4ee36d5b7