### PR TITLE
Avoid double-counting passive gubs

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -34,7 +34,8 @@ exports.syncGubs = functions.https.onCall(async (data, ctx) => {
   const snap = await userRef.once('value');
   const { score = 0, lastUpdated = Date.now() } = snap.val() || {};
   const now = Date.now();
-  const earned = rate * ((now - lastUpdated) / 1000);
+  const elapsed = delta === 0 ? now - lastUpdated : 0;
+  const earned = rate * (elapsed / 1000);
   const newScore = Math.max(0, Math.floor(score + earned + delta));
   await userRef.update({ score: newScore, lastUpdated: now });
   return { score: newScore };


### PR DESCRIPTION
## Summary
- Prevent the syncGubs cloud function from granting passive earnings when client delta is present to stop doubled gub accrual.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896851120b08323af9be7adf4ebc9c3