### PR TITLE
Ensure rapid clicks aren't lost during server sync

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -143,16 +143,25 @@ window.addEventListener("DOMContentLoaded", () => {
       let feralTimeout;
       let scoreDirty = false;
 
+      let syncing = false;
       async function syncGubsFromServer() {
+        if (syncing) return;
+        syncing = true;
+        const delta = unsyncedDelta;
+        unsyncedDelta = 0;
         try {
-          const res = await syncGubsFn({ delta: unsyncedDelta });
+          const res = await syncGubsFn({ delta });
           if (res.data && typeof res.data.score === "number") {
-            globalCount = displayedCount = res.data.score;
-            unsyncedDelta = 0;
+            globalCount = displayedCount = res.data.score + unsyncedDelta;
             renderCounter();
+          } else {
+            unsyncedDelta += delta;
           }
         } catch (err) {
+          unsyncedDelta += delta;
           console.error("syncGubs failed", err);
+        } finally {
+          syncing = false;
         }
       }
 


### PR DESCRIPTION
## Summary
- handle concurrent scoreboard syncs safely
- capture and reapply unsynced clicks while awaiting server

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689686e4d77c8323af61ab057dbca2f8