### PR TITLE
Reposition chat and leaderboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,8 +115,8 @@
     <div id="golden-counter">
       <div id="gubTotal">Gubs: 0 (0 gub/s)</div>
     </div>
+    <div id="leaderboard"><strong>Leaderboard</strong><br />Loading…</div>
     <div id="bottom-ui">
-      <div id="leaderboard"><strong>Leaderboard</strong><br />Loading…</div>
       <div id="chat">
         <div id="chatResizeHandle"></div>
         <div id="messages"></div>

--- a/styles/base.css
+++ b/styles/base.css
@@ -296,11 +296,17 @@ body {
   line-height: 1.2;
 }
 #leaderboard {
+  position: fixed;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
   background: rgba(0, 0, 0, 0.6);
   color: #fff;
-  padding: 10px;
+  padding: 12px;
   border-radius: 6px;
   font-family: sans-serif;
+  width: 200px;
+  line-height: 1.4;
 }
 #discordWrapper {
   position: absolute;

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -1,12 +1,12 @@
 #chat {
-  width: 420px;
-  height: 200px; /* initial size, can be resized by user */
+  width: 480px;
+  height: 240px; /* initial size, can be resized by user */
   overflow: auto;
   border-radius: 8px;
   background: rgba(0, 0, 0, 0.6);
   color: #fff;
   font-family: sans-serif;
-  padding: 8px;
+  padding: 12px;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- Anchor leaderboard on left side with more spacing
- Place chat at bottom-left and increase chat box size

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896910f1c0c8323a0067b900682ed69