### PR TITLE
feat: replace username prompt with modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,18 @@
     </div>
     <div id="clickMe">click me</div>
     <canvas id="visualizer"></canvas>
+    <div id="usernameOverlay" style="display: none">
+      <div id="usernameModal">
+        <h2>Choose a username</h2>
+        <input
+          id="usernameInput"
+          type="text"
+          maxlength="20"
+          placeholder="Username"
+        />
+        <button id="usernameSubmit">Start</button>
+      </div>
+    </div>
     <script type="module" src="src/main.js"></script>
     <div id="feedbackModal">
       <textarea

--- a/src/main.js
+++ b/src/main.js
@@ -38,17 +38,31 @@ window.addEventListener("DOMContentLoaded", () => {
       .slice(0, 20);
   }
 
-  // 1. Prompt & sanitize username
+  // Username handling
   let username = sanitizeUsername(localStorage.getItem("gubUser"));
-  if (!username || username.length < 3) {
-    do {
-      username = sanitizeUsername(
-        prompt("Enter a username for the leaderboard:"),
-      );
-    } while (!username || username.length < 3);
-    localStorage.setItem("gubUser", username);
+
+  function showUsernamePrompt() {
+    const overlay = document.getElementById("usernameOverlay");
+    const input = document.getElementById("usernameInput");
+    const submit = document.getElementById("usernameSubmit");
+    overlay.style.display = "flex";
+    function accept() {
+      const u = sanitizeUsername(input.value);
+      if (u.length >= 3) {
+        username = u;
+        localStorage.setItem("gubUser", username);
+        overlay.style.display = "none";
+        initApp();
+      }
+    }
+    submit.addEventListener("click", accept);
+    input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") accept();
+    });
+    input.focus();
   }
 
+  function initApp() {
   // 2. Initialize Firebase
   const firebaseConfig = {
     apiKey: "AIzaSyBc2cDT3md2pk28dFMDoCeCgw37tpGBEjM",
@@ -1099,4 +1113,11 @@ window.addEventListener("DOMContentLoaded", () => {
   const styleEl = document.createElement("style");
   styleEl.textContent = `@keyframes flash{0%{background:#111}25%{background:#ff0}50%{background:#0ff}75%{background:#f0f}100%{background:#111}}@keyframes spinmove{0%{transform:scale(1) rotate(0deg)}50%{transform:scale(1.2) rotate(180deg)}100%{transform:scale(1) rotate(360deg)}}`;
   document.head.appendChild(styleEl);
+  }
+
+  if (username && username.length >= 3) {
+    initApp();
+  } else {
+    showUsernamePrompt();
+  }
 });

--- a/styles/base.css
+++ b/styles/base.css
@@ -382,3 +382,40 @@ body {
   float: right;
 }
 
+#usernameOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 100000;
+}
+
+#usernameModal {
+  background: #222;
+  padding: 20px;
+  border-radius: 8px;
+  text-align: center;
+  color: #fff;
+  font-family: sans-serif;
+}
+
+#usernameModal input {
+  width: 200px;
+  padding: 8px;
+  margin-bottom: 10px;
+  border: none;
+  border-radius: 4px;
+}
+
+#usernameModal button {
+  padding: 8px 16px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+


### PR DESCRIPTION
## Summary
- replace blocking browser prompt with custom modal for username
- style and include modal markup

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896922e867083238590b985147dae9f