### PR TITLE
Position leaderboard above chat

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,24 +115,26 @@
     <div id="golden-counter">
       <div id="gubTotal">Gubs: 0 (0 gub/s)</div>
     </div>
-    <div id="leaderboard"><strong>Leaderboard</strong><br />Loading…</div>
     <div id="bottom-ui">
-      <div id="chat">
-        <div id="chatResizeHandle"></div>
-        <div id="messages"></div>
-        <div id="mentionSuggestions"></div>
-        <form id="chatForm">
-          <input
-            id="chatInput"
-            type="text"
-            placeholder="Type a message…"
-            autocomplete="off"
-            maxlength="200"
-          />
-          <button type="submit">Send</button>
-        </form>
+      <div id="leaderboard"><strong>Leaderboard</strong><br />Loading…</div>
+      <div id="chat-row">
+        <div id="chat">
+          <div id="chatResizeHandle"></div>
+          <div id="messages"></div>
+          <div id="mentionSuggestions"></div>
+          <form id="chatForm">
+            <input
+              id="chatInput"
+              type="text"
+              placeholder="Type a message…"
+              autocomplete="off"
+              maxlength="200"
+            />
+            <button type="submit">Send</button>
+          </form>
+        </div>
+        <div id="online-users">Online: …</div>
       </div>
-      <div id="online-users">Online: …</div>
     </div>
     <div id="twitchPlayer"></div>
     <div id="gub-wrapper">

--- a/styles/base.css
+++ b/styles/base.css
@@ -253,14 +253,21 @@ body {
   bottom: 10px;
   left: 10px;
   display: flex;
+  flex-direction: column;
   gap: 10px;
-  align-items: flex-end;
+  align-items: flex-start;
   z-index: 10000;
   pointer-events: none;
 }
 
 #bottom-ui > * {
   pointer-events: auto;
+}
+
+#chat-row {
+  display: flex;
+  gap: 10px;
+  align-items: flex-end;
 }
 
 #online-users {
@@ -296,10 +303,6 @@ body {
   line-height: 1.2;
 }
 #leaderboard {
-  position: fixed;
-  left: 10px;
-  top: 50%;
-  transform: translateY(-50%);
   background: rgba(0, 0, 0, 0.6);
   color: #fff;
   padding: 12px;


### PR DESCRIPTION
## Summary
- Move leaderboard into bottom UI and stack it above the chat
- Clean up CSS to remove fixed positioning and add layout container

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68969321317883239765467bca207753