### PR TITLE
Keep leaderboard attached to resizable chat

### DIFF
--- a/src/chat.js
+++ b/src/chat.js
@@ -6,10 +6,16 @@ export function initChat({ db, username, allUsers, sanitizeUsername, playMention
   const mentionSuggestions = document.getElementById("mentionSuggestions");
   const chatBox = document.getElementById("chat");
   const resizeHandle = document.getElementById("chatResizeHandle");
+  const leaderboard = document.getElementById("leaderboard");
 
   const savedChatWidth = localStorage.getItem("chatWidth");
   const savedChatHeight = localStorage.getItem("chatHeight");
-  if (savedChatWidth) chatBox.style.width = savedChatWidth + "px";
+  if (savedChatWidth) {
+    chatBox.style.width = savedChatWidth + "px";
+    leaderboard.style.width = savedChatWidth + "px";
+  } else {
+    leaderboard.style.width = chatBox.offsetWidth + "px";
+  }
   if (savedChatHeight) chatBox.style.height = savedChatHeight + "px";
 
   const saveChatSize = () => {
@@ -38,6 +44,7 @@ export function initChat({ db, username, allUsers, sanitizeUsername, playMention
     const newHeight = Math.max(100, startHeight - (touch.clientY - startY));
     chatBox.style.width = newWidth + "px";
     chatBox.style.height = newHeight + "px";
+    leaderboard.style.width = newWidth + "px";
   }
 
   function stopResize() {

--- a/styles/base.css
+++ b/styles/base.css
@@ -177,7 +177,7 @@ body {
   top: 40px;
   right: 10px;
   display: flex;
-  gap: 10px;
+  gap: 0;
   z-index: 10001;
 }
 #topRight button {
@@ -254,7 +254,7 @@ body {
   left: 10px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 0;
   align-items: flex-start;
   z-index: 10000;
   pointer-events: none;
@@ -308,7 +308,6 @@ body {
   padding: 12px;
   border-radius: 6px;
   font-family: sans-serif;
-  width: 200px;
   line-height: 1.4;
 }
 #discordWrapper {


### PR DESCRIPTION
## Summary
- Remove spacing so leaderboard sits directly atop chat
- Sync leaderboard width with resizable chat box to stay aligned during resize

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68969505ff1083239ce95b56a064de53