### PR TITLE
Decouple leaderboard width from chat and reposition online counter

### DIFF
--- a/src/chat.js
+++ b/src/chat.js
@@ -6,16 +6,9 @@ export function initChat({ db, username, allUsers, sanitizeUsername, playMention
   const mentionSuggestions = document.getElementById("mentionSuggestions");
   const chatBox = document.getElementById("chat");
   const resizeHandle = document.getElementById("chatResizeHandle");
-  const leaderboard = document.getElementById("leaderboard");
-
   const savedChatWidth = localStorage.getItem("chatWidth");
   const savedChatHeight = localStorage.getItem("chatHeight");
-  if (savedChatWidth) {
-    chatBox.style.width = savedChatWidth + "px";
-    leaderboard.style.width = savedChatWidth + "px";
-  } else {
-    leaderboard.style.width = chatBox.offsetWidth + "px";
-  }
+  if (savedChatWidth) chatBox.style.width = savedChatWidth + "px";
   if (savedChatHeight) chatBox.style.height = savedChatHeight + "px";
 
   const saveChatSize = () => {
@@ -44,7 +37,6 @@ export function initChat({ db, username, allUsers, sanitizeUsername, playMention
     const newHeight = Math.max(100, startHeight - (touch.clientY - startY));
     chatBox.style.width = newWidth + "px";
     chatBox.style.height = newHeight + "px";
-    leaderboard.style.width = newWidth + "px";
   }
 
   function stopResize() {

--- a/styles/base.css
+++ b/styles/base.css
@@ -254,7 +254,7 @@ body {
   left: 10px;
   display: flex;
   flex-direction: column;
-  gap: 0;
+  gap: 8px;
   align-items: flex-start;
   z-index: 10000;
   pointer-events: none;
@@ -266,8 +266,9 @@ body {
 
 #chat-row {
   display: flex;
-  gap: 10px;
-  align-items: flex-end;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-start;
 }
 
 #online-users {


### PR DESCRIPTION
## Summary
- Stop forcing the leaderboard to match the chat's width
- Stack online user count below chat and add spacing between leaderboard and chat

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896978a0ba483239a50a4cb3f6120de