### PR TITLE
feat: refine offline passive gub earnings

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -35,8 +35,10 @@ exports.syncGubs = functions.https.onCall(async (data, ctx) => {
   const { score = 0, lastUpdated = Date.now() } = snap.val() || {};
   const now = Date.now();
   const elapsed = delta === 0 ? now - lastUpdated : 0;
-  const earned = rate * (elapsed / 1000);
+  // Award only 0.25% of the normal passive rate while the user was away
+  const earned = rate * 0.0025 * (elapsed / 1000);
+  const offlineEarned = Math.floor(earned);
   const newScore = Math.max(0, Math.floor(score + earned + delta));
   await userRef.update({ score: newScore, lastUpdated: now });
-  return { score: newScore };
+  return { score: newScore, offlineEarned };
 });

--- a/index.html
+++ b/index.html
@@ -141,6 +141,10 @@
     <div id="clickMe">click me</div>
     <canvas id="visualizer"></canvas>
     <script type="module" src="src/main.js"></script>
+    <div id="offlineModal">
+      <div id="offlineMessage"></div>
+      <button id="offlineClose">OK</button>
+    </div>
     <div id="feedbackModal">
       <textarea
         id="feedbackInput"

--- a/src/main.js
+++ b/src/main.js
@@ -73,6 +73,13 @@ window.addEventListener("DOMContentLoaded", () => {
       const uid = firebase.auth().currentUser.uid;
       const allUsers = new Set([username]);
 
+      const offlineModal = document.getElementById("offlineModal");
+      const offlineMessage = document.getElementById("offlineMessage");
+      const offlineClose = document.getElementById("offlineClose");
+      offlineClose.addEventListener("click", () => {
+        offlineModal.style.display = "none";
+      });
+
       const versionRef = db.ref("config/version");
       versionRef.on("value", (snap) => {
         const serverVersion = snap.val();
@@ -139,6 +146,7 @@ window.addEventListener("DOMContentLoaded", () => {
         globalCount = 0,
         displayedCount = 0,
         unsyncedDelta = 0;
+      let offlineShown = false;
       let gubRateMultiplier = 1;
       let feralTimeout;
       let scoreDirty = false;
@@ -153,9 +161,16 @@ window.addEventListener("DOMContentLoaded", () => {
         try {
           const res = await syncGubsFn({ delta: sendDelta });
           if (res.data && typeof res.data.score === "number") {
+            const { score, offlineEarned = 0 } = res.data;
             // Server stores integer scores, so re-add any local remainder
-            globalCount = displayedCount = res.data.score + unsyncedDelta;
+            globalCount = displayedCount = score + unsyncedDelta;
             renderCounter();
+            if (!offlineShown && offlineEarned > 0) {
+              offlineMessage.textContent =
+                `You earned ${abbreviateNumber(offlineEarned)} gubs while you were away!`;
+              offlineModal.style.display = "block";
+              offlineShown = true;
+            }
           } else {
             // Revert on failure to ensure no loss
             unsyncedDelta += sendDelta;

--- a/styles/base.css
+++ b/styles/base.css
@@ -378,6 +378,24 @@ body {
 #feedbackSee {
   float: left;
 }
+
+#offlineModal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(0, 0, 0, 0.85);
+  color: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  font-family: sans-serif;
+  text-align: center;
+  display: none;
+  z-index: 10002;
+}
+#offlineModal button {
+  margin-top: 10px;
+}
 #feedbackSubmit {
   float: right;
 }


### PR DESCRIPTION
## Summary
- return offline passive gub earnings from syncGubs
- display centered popup showing offline gubs earned with dismiss button

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689690318c788323bc31aeef23c62344