### PR TITLE
Refactor offline gub calculation with tests

### DIFF
--- a/functions/__tests__/offline.test.js
+++ b/functions/__tests__/offline.test.js
@@ -1,0 +1,18 @@
+/* eslint-env jest */
+const { calculateOfflineGubs } = require('../offline');
+
+describe('calculateOfflineGubs', () => {
+  test('awards 25% of rate per second of elapsed time', () => {
+    const rate = 100; // gubs per second
+    const lastUpdated = 0;
+    const now = 4000; // 4 seconds later
+    expect(calculateOfflineGubs(rate, lastUpdated, now)).toBe(100);
+  });
+
+  test('returns 0 when elapsed time is negative', () => {
+    const rate = 50;
+    const lastUpdated = 10000;
+    const now = 5000; // time went backwards
+    expect(calculateOfflineGubs(rate, lastUpdated, now)).toBe(0);
+  });
+});

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,5 +1,6 @@
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
+const { calculateOfflineGubs } = require('./offline');
 admin.initializeApp();
 
 exports.syncGubs = functions.https.onCall(async (data, ctx) => {
@@ -38,9 +39,7 @@ exports.syncGubs = functions.https.onCall(async (data, ctx) => {
 
   let offlineEarned = 0;
   if (requestOffline) {
-    const elapsed = now - lastUpdated;
-    const earned = rate * 0.0025 * (elapsed / 1000);
-    offlineEarned = Math.floor(earned);
+    offlineEarned = calculateOfflineGubs(rate, lastUpdated, now);
   }
   const newScore = Math.max(0, score + delta + offlineEarned);
 

--- a/functions/offline.js
+++ b/functions/offline.js
@@ -1,0 +1,9 @@
+const OFFLINE_RATE = 0.25; // earn 25% of passive rate while offline
+
+function calculateOfflineGubs(rate, lastUpdated, now = Date.now()) {
+  const elapsed = Math.max(0, now - lastUpdated); // milliseconds
+  const earned = rate * OFFLINE_RATE * (elapsed / 1000); // 25% of rate per second
+  return Math.floor(earned);
+}
+
+module.exports = { calculateOfflineGubs };


### PR DESCRIPTION
## Summary
- centralize offline gub formula in `calculateOfflineGubs`
- handle negative elapsed time when awarding offline gubs
- add unit tests covering offline reward calculation
- award 25% of passive gains while offline

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68969f903f40832396f44c0225607c7b