### PR TITLE
Preload Twitch stream and simplify display

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1074,22 +1074,32 @@ window.addEventListener("DOMContentLoaded", () => {
   const chaosBtn = document.getElementById("chaosBtn");
   const twitchBtn = document.getElementById("twitchBtn");
   const twitchBox = document.getElementById("twitchPlayer");
+  twitchBox.style.display = "block";
+  twitchBox.style.visibility = "hidden";
+  const twitchEmbed = new Twitch.Embed("twitchPlayer", {
+    width: "100%",
+    height: "100%",
+    channel: "harupi",
+    layout: "video",
+    parent: [location.hostname],
+    autoplay: false,
+    muted: true,
+  });
+  let twitchPlayer;
+  twitchEmbed.addEventListener(Twitch.Embed.VIDEO_READY, () => {
+    twitchPlayer = twitchEmbed.getPlayer();
+    twitchPlayer.setMuted(true);
+  });
   let twitchShown = false;
 
   twitchBtn.onclick = () => {
     if (!twitchShown) {
-      twitchBox.style.display = "block";
-      new Twitch.Embed("twitchPlayer", {
-        width: "100%",
-        height: "100%",
-        channel: "harupi",
-        layout: "video",
-        parent: [location.hostname],
-      });
+      twitchBox.style.visibility = "visible";
+      twitchPlayer && twitchPlayer.play();
       twitchBtn.textContent = "Hide Stream";
     } else {
-      twitchBox.innerHTML = "";
-      twitchBox.style.display = "none";
+      twitchPlayer && twitchPlayer.pause();
+      twitchBox.style.visibility = "hidden";
       twitchBtn.textContent = "Show Stream";
     }
     twitchShown = !twitchShown;

--- a/styles/base.css
+++ b/styles/base.css
@@ -287,8 +287,6 @@ body {
   height: 300px;
   z-index: 20000;
   display: none;
-  box-shadow: 0 0 8px #000;
-  border-radius: 8px;
   overflow: hidden;
 }
 #golden-counter {


### PR DESCRIPTION
## Summary
- Preload Twitch embed off-screen so the stream starts instantly when shown
- Remove extra player chrome and styling for a simpler, borderless stream window

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896ab9681008323a3366e28dcbb4d5f