### PR TITLE
Fix movement toggle button width

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -77,6 +77,10 @@ body {
   cursor: pointer;
 }
 
+#moveToggle {
+  width: 140px;
+}
+
 .rainbow-text {
   font-size: 2rem;
   font-weight: bold;


### PR DESCRIPTION
## Summary
- prevent movement toggle button from resizing by giving it a fixed width

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896b21b748083238f4c2cf3678ea494