### PR TITLE
Improve settings menu layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,16 +80,26 @@
     </div>
 
     <div id="perfMenu">
-      <div>
-        Speed: <button id="spdDec">-</button><span id="spdVal">2</span
-        ><button id="spdInc">+</button>
+      <div class="setting-row">
+        <span class="setting-label">Speed:</span>
+        <span class="setting-controls">
+          <button id="spdDec">-</button><span id="spdVal">2</span
+          ><button id="spdInc">+</button>
+        </span>
       </div>
-      <div>
-        Images: <button id="imgDec">-</button><span id="imgVal">20</span
-        ><button id="imgInc">+</button>
+      <div class="setting-row">
+        <span class="setting-label">Images:</span>
+        <span class="setting-controls">
+          <button id="imgDec">-</button><span id="imgVal">20</span
+          ><button id="imgInc">+</button>
+        </span>
       </div>
-      <div><button id="moveToggle">Pause Movement</button></div>
-      <div><button id="qualityBtn">High Quality: Off</button></div>
+      <div class="center-row">
+        <button id="moveToggle">Pause Movement</button>
+      </div>
+      <div class="center-row">
+        <button id="qualityBtn">High Quality: Off</button>
+      </div>
       <label
         for="volumeSlider"
         style="margin-top: 8px; display: block; color: #fff; font-weight: bold"

--- a/styles/base.css
+++ b/styles/base.css
@@ -77,6 +77,27 @@ body {
   cursor: pointer;
 }
 
+#perfMenu .setting-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+#perfMenu .setting-controls {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+#perfMenu .center-row {
+  display: flex;
+  justify-content: center;
+}
+
+#qualityBtn {
+  width: 140px;
+}
+
 #moveToggle {
   width: 140px;
 }
@@ -450,4 +471,3 @@ body {
   border-radius: 4px;
   cursor: pointer;
 }
-


### PR DESCRIPTION
## Summary
- Align speed and image controls using flex rows
- Center high quality toggle like the resume movement button

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896b53181a08323896545ace6e6d03b