### PR TITLE
Harden leaderboard score updates

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -4,14 +4,16 @@
       ".read": true,
       "$uid": {
         ".read": "auth != null && auth.uid === $uid",
-        ".write": "auth != null && auth.uid === $uid",
         "score": {
+          ".write": false,
           ".validate": "newData.isNumber() && newData.val() >= 0"
         },
         "username": {
+          ".write": "auth != null && auth.uid === $uid",
           ".validate": "newData.isString() && newData.val().matches(/^[A-Za-z0-9_]{3,20}$/)"
         },
         "lastUpdated": {
+          ".write": false,
           ".validate": "newData.isNumber()"
         }
       }

--- a/functions/index.js
+++ b/functions/index.js
@@ -3,12 +3,15 @@ const admin = require('firebase-admin');
 const { calculateOfflineGubs } = require('./offline');
 admin.initializeApp();
 
+const MAX_DELTA = 1000; // clamp client-supplied score changes
+
 exports.syncGubs = functions.https.onCall(async (data, ctx) => {
   const uid = ctx.auth?.uid;
   if (!uid) {
     throw new functions.https.HttpsError('unauthenticated');
   }
-  const delta = typeof data?.delta === 'number' ? data.delta : 0;
+  let delta = typeof data?.delta === 'number' ? Math.floor(data.delta) : 0;
+  delta = Math.max(-MAX_DELTA, Math.min(MAX_DELTA, delta));
   const requestOffline = !!data?.offline;
 
   const db = admin.database();


### PR DESCRIPTION
## Summary
- block client-side score writes in realtime DB rules
- clamp user-provided score deltas in `syncGubs`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896b888dfd083238026a8b0116dd525