### PR TITLE
fix: stabilize counter updates during rapid clicks

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -260,8 +260,9 @@ window.addEventListener("DOMContentLoaded", () => {
         userRef.on("value", (s) => {
           const v = s.val();
           if (typeof v === "number") {
-            globalCount = displayedCount = v;
-            scoreDirty = false;
+            const total = v + unsyncedDelta;
+            globalCount = displayedCount = total;
+            scoreDirty = unsyncedDelta !== 0;
             renderCounter();
           }
         });


### PR DESCRIPTION
## Summary
- preserve local unsynced gubs when realtime updates arrive

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896bc42139883239d202fde6dcc3410