### PR TITLE
fix: ensure 7tv emotes render after inactivity

### DIFF
--- a/src/chat.js
+++ b/src/chat.js
@@ -52,7 +52,7 @@ export function initChat({ db, username, allUsers, sanitizeUsername, playMention
 
   const emoteMap = {};
   const HARUPI_SET = "01H6Q79JP80007TK4TYM94A0B4";
-  fetch(`https://7tv.io/v3/emote-sets/${HARUPI_SET}`)
+  const emotesLoaded = fetch(`https://7tv.io/v3/emote-sets/${HARUPI_SET}`)
     .then((r) => r.json())
     .then((d) => {
       d.emotes.forEach((e) => {
@@ -87,6 +87,7 @@ export function initChat({ db, username, allUsers, sanitizeUsername, playMention
   }
 
   async function emoteHTML(text) {
+    await emotesLoaded;
     let safe = escapeHTML(text);
     const tokens = safe.split(/(\s+)/);
     for (let i = 0; i < tokens.length; i++) {


### PR DESCRIPTION
## Summary
- wait for 7TV emote set to load before processing chat messages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896be03f8608323853a52663dbe700c