### PR TITLE
Add Comic Sans font toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,6 +100,9 @@
       <div class="center-row">
         <button id="qualityBtn">High Quality: Off</button>
       </div>
+      <div class="center-row">
+        <button id="comicBtn">Comic Sans: Off</button>
+      </div>
       <label
         for="volumeSlider"
         style="margin-top: 8px; display: block; color: #fff; font-weight: bold"

--- a/src/main.js
+++ b/src/main.js
@@ -882,6 +882,10 @@ window.addEventListener("DOMContentLoaded", () => {
     "low_floater18.jpg",
   ];
   let useHighQuality = localStorage.getItem("gubHighQuality") === "true";
+  let useComicSans = localStorage.getItem("gubComicSans") === "true";
+  if (useComicSans) {
+    document.body.classList.add("comic-sans");
+  }
   let images = useHighQuality ? highImages : lowImages;
   const texts = [
     "bark",
@@ -993,9 +997,11 @@ window.addEventListener("DOMContentLoaded", () => {
   const imgVal = document.getElementById("imgVal");
   const moveToggle = document.getElementById("moveToggle");
   const qualityBtn = document.getElementById("qualityBtn");
+  const comicBtn = document.getElementById("comicBtn");
   qualityBtn.textContent = useHighQuality
     ? "High Quality: On"
     : "High Quality: Off";
+  comicBtn.textContent = useComicSans ? "Comic Sans: On" : "Comic Sans: Off";
   qualityBtn.onclick = () => {
     useHighQuality = !useHighQuality;
     localStorage.setItem("gubHighQuality", useHighQuality);
@@ -1009,6 +1015,14 @@ window.addEventListener("DOMContentLoaded", () => {
         img.src = images[f.imgIdx];
       }
     });
+  };
+  comicBtn.onclick = () => {
+    useComicSans = !useComicSans;
+    document.body.classList.toggle("comic-sans", useComicSans);
+    comicBtn.textContent = useComicSans
+      ? "Comic Sans: On"
+      : "Comic Sans: Off";
+    localStorage.setItem("gubComicSans", useComicSans);
   };
 
   settingsBtn.onclick = () => {

--- a/styles/base.css
+++ b/styles/base.css
@@ -102,6 +102,10 @@ body {
   width: 140px;
 }
 
+#comicBtn {
+  width: 140px;
+}
+
 .rainbow-text {
   font-size: 2rem;
   font-weight: bold;
@@ -470,4 +474,9 @@ body {
   border: none;
   border-radius: 4px;
   cursor: pointer;
+}
+
+body.comic-sans,
+body.comic-sans * {
+  font-family: "Comic Sans MS", "Comic Sans", cursive !important;
 }


### PR DESCRIPTION
## Summary
- allow users to switch site-wide font to Comic Sans via new settings toggle
- remember font selection in local storage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896bf119f9083239e5ddfba68e08311