### PR TITLE
Fix passive gubs when tab hidden

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -165,6 +165,7 @@ window.addEventListener("DOMContentLoaded", () => {
       let gubRateMultiplier = 1;
       let feralTimeout;
       let scoreDirty = false;
+      let hiddenStart = 0;
 
       let syncing = false;
       async function syncGubsFromServer(requestOffline = false) {
@@ -508,9 +509,16 @@ window.addEventListener("DOMContentLoaded", () => {
       }
 
       document.addEventListener("visibilitychange", () => {
-        if (!document.hidden) {
+        if (document.hidden) {
+          hiddenStart = Date.now();
+        } else {
           passiveWorker.postMessage({ type: "reset" });
-          syncGubsFromServer(true);
+          if (hiddenStart) {
+            const elapsedSec = (Date.now() - hiddenStart) / 1000;
+            gainGubs(passiveRatePerSec * elapsedSec);
+            hiddenStart = 0;
+          }
+          syncGubsFromServer();
         }
       });
       // main gub handler


### PR DESCRIPTION
## Summary
- Track time while tab is hidden to grant full passive gubs
- Sync without offline flag and credit missed gubs when returning

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896c2abd9ec8323b90ad2eb78f8283c