### PR TITLE
fix: ensure score sync updates database

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -91,6 +91,14 @@
         }
       }
     },
+    "rateLimits": {
+      ".read": false,
+      ".write": false
+    },
+    "goldenTokens": {
+      ".read": false,
+      ".write": false
+    },
     "config": {
       ".read": true,
       ".write": false


### PR DESCRIPTION
## Summary
- handle rate-limit storage errors without aborting sync
- persist click sync via root update to Realtime DB
- restrict rateLimits and goldenTokens paths in database rules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689758c51bdc8323a6d98af234d76c07