### PR TITLE
Add transactional purchase function

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -50,7 +50,7 @@
     "shop_v2": {
       "$uid": {
         ".read": "auth != null && auth.uid === $uid",
-        ".write": "auth != null && auth.uid === $uid",
+        ".write": false,
         "$item": {
           ".validate": "newData.isNumber() && newData.val() >= 0"
         }

--- a/functions/index.js
+++ b/functions/index.js
@@ -49,3 +49,72 @@ exports.syncGubs = functions.https.onCall(async (data, ctx) => {
   await userRef.update({ score: newScore, lastUpdated: now });
   return { score: newScore, offlineEarned };
 });
+
+const COST_MULTIPLIER = 1.15;
+const SHOP_ITEMS = {
+  passiveMaker: 100,
+  guberator: 500,
+  gubmill: 2000,
+  gubsolar: 10000,
+  gubfactory: 50000,
+  gubhydro: 250000,
+  gubnuclear: 1000000,
+  gubquantum: 5000000,
+  gubai: 25000000,
+  gubclone: 125000000,
+  gubspace: 625000000,
+  intergalactic: 3125000000,
+};
+
+exports.purchaseItem = functions.https.onCall(async (data, ctx) => {
+  const uid = ctx.auth?.uid;
+  if (!uid) {
+    throw new functions.https.HttpsError('unauthenticated');
+  }
+  const item = data?.item;
+  const quantity = Math.max(1, Math.floor(data?.quantity || 1));
+  if (!SHOP_ITEMS[item]) {
+    throw new functions.https.HttpsError('invalid-argument', 'Unknown item');
+  }
+
+  const db = admin.database();
+  const result = await db.ref().runTransaction((root) => {
+    if (root === null) root = {};
+    const user = root.leaderboard_v3?.[uid] || {};
+    const score = user.score || 0;
+    const owned = root.shop_v2?.[uid]?.[item] || 0;
+
+    let cost = 0;
+    for (let i = 0; i < quantity; i++) {
+      cost += Math.floor(
+        SHOP_ITEMS[item] * Math.pow(COST_MULTIPLIER, owned + i),
+      );
+    }
+    if (score < cost) {
+      return; // abort
+    }
+
+    user.score = score - cost;
+    user.lastUpdated = Date.now();
+    if (!root.leaderboard_v3) root.leaderboard_v3 = {};
+    root.leaderboard_v3[uid] = user;
+
+    if (!root.shop_v2) root.shop_v2 = {};
+    if (!root.shop_v2[uid]) root.shop_v2[uid] = {};
+    root.shop_v2[uid][item] = owned + quantity;
+
+    return root;
+  });
+
+  if (!result.committed) {
+    throw new functions.https.HttpsError(
+      'failed-precondition',
+      'Not enough gubs',
+    );
+  }
+
+  const newScore =
+    result.snapshot.child(`leaderboard_v3/${uid}/score`).val() || 0;
+  const newOwned = result.snapshot.child(`shop_v2/${uid}/${item}`).val() || 0;
+  return { score: newScore, owned: newOwned };
+});

--- a/src/main.js
+++ b/src/main.js
@@ -84,6 +84,7 @@ window.addEventListener("DOMContentLoaded", () => {
       const db = firebase.database();
       const functions = firebase.functions();
       const syncGubsFn = functions.httpsCallable("syncGubs");
+      const purchaseItemFn = functions.httpsCallable("purchaseItem");
       const uid = firebase.auth().currentUser.uid;
       const allUsers = new Set([username]);
 
@@ -165,41 +166,42 @@ window.addEventListener("DOMContentLoaded", () => {
       let feralTimeout;
       let scoreDirty = false;
 
-      let syncing = false;
+      let syncPromise = null;
       async function syncGubsFromServer(requestOffline = false) {
-        if (syncing) return;
-        syncing = true;
+        if (syncPromise) return syncPromise;
         // Only sync whole gubs to avoid dropping fractional amounts
         const sendDelta = Math.floor(unsyncedDelta);
         unsyncedDelta -= sendDelta; // keep remainder locally
-        try {
-          const res = await syncGubsFn({
-            delta: sendDelta,
-            offline: requestOffline,
-          });
-          if (res.data && typeof res.data.score === "number") {
-            const { score, offlineEarned = 0 } = res.data;
-            // Server stores integer scores, so re-add any local remainder
-            globalCount = displayedCount = score + unsyncedDelta;
-            renderCounter();
+        syncPromise = (async () => {
+          try {
+            const res = await syncGubsFn({
+              delta: sendDelta,
+              offline: requestOffline,
+            });
+            if (res.data && typeof res.data.score === "number") {
+              const { score, offlineEarned = 0 } = res.data;
+              // Server stores integer scores, so re-add any local remainder
+              globalCount = displayedCount = score + unsyncedDelta;
+              renderCounter();
 
-            if (requestOffline && !offlineShown && offlineEarned > 0) {
-
-              offlineMessage.textContent =
-                `You earned ${abbreviateNumber(offlineEarned)} gubs while you were away!`;
-              offlineModal.style.display = "block";
-              offlineShown = true;
+              if (requestOffline && !offlineShown && offlineEarned > 0) {
+                offlineMessage.textContent =
+                  `You earned ${abbreviateNumber(offlineEarned)} gubs while you were away!`;
+                offlineModal.style.display = "block";
+                offlineShown = true;
+              }
+            } else {
+              // Revert on failure to ensure no loss
+              unsyncedDelta += sendDelta;
             }
-          } else {
-            // Revert on failure to ensure no loss
+          } catch (err) {
             unsyncedDelta += sendDelta;
+            console.error("syncGubs failed", err);
+          } finally {
+            syncPromise = null;
           }
-        } catch (err) {
-          unsyncedDelta += sendDelta;
-          console.error("syncGubs failed", err);
-        } finally {
-          syncing = false;
-        }
+        })();
+        return syncPromise;
       }
 
       function queueScoreUpdate() {
@@ -743,14 +745,28 @@ window.addEventListener("DOMContentLoaded", () => {
           await syncGubsFromServer();
           const cost = totalCost(quantity);
           if (globalCount >= cost) {
-            spendGubs(cost);
-            owned[item.id] += quantity;
-            document.getElementById(`owned-${item.id}`).textContent =
-              owned[item.id];
-            db.ref(`shop_v2/${uid}/${item.id}`).set(owned[item.id]);
-            updatePassiveIncome();
-            updateCostDisplay();
-            await syncGubsFromServer();
+            try {
+              const res = await purchaseItemFn({
+                item: item.id,
+                quantity,
+              });
+              if (res.data) {
+                if (typeof res.data.owned === "number") {
+                  owned[item.id] = res.data.owned;
+                  document.getElementById(`owned-${item.id}`).textContent =
+                    owned[item.id];
+                }
+                if (typeof res.data.score === "number") {
+                  globalCount = displayedCount = res.data.score;
+                  unsyncedDelta = 0;
+                  renderCounter();
+                }
+              }
+              updatePassiveIncome();
+              updateCostDisplay();
+            } catch (err) {
+              console.error("purchaseItem failed", err);
+            }
           }
         }
 


### PR DESCRIPTION
## Summary
- add `purchaseItem` Cloud Function to validate balance and update score and shop in one transaction
- call new function from client instead of direct database writes
- deny client writes to `shop_v2` in security rules
- wait for any in-flight sync before requesting purchases to avoid balance desyncs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689783b8d2c48323abbcb37e2b5b062e