### PR TITLE
Fix Realtime Database transaction call in purchaseItem

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -98,7 +98,7 @@ exports.purchaseItem = functions.https.onCall(async (data, ctx) => {
   }
   try {
     const db = admin.database();
-    const result = await db.ref().runTransaction((root) => {
+    const result = await db.ref().transaction((root) => {
       if (root === null) root = {};
       const user = root.leaderboard_v3?.[uid] || {};
       const score = user.score || 0;


### PR DESCRIPTION
## Summary
- use `transaction` instead of nonexistent `runTransaction` on Realtime Database ref in `purchaseItem`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_6898ce59b9cc8323a9b7d7d25c501416