### PR TITLE
Add detailed logging for gub sync and purchases

### DIFF
--- a/functions/__tests__/purchase-item.test.js
+++ b/functions/__tests__/purchase-item.test.js
@@ -2,23 +2,27 @@
 
 // Mock firebase-admin before requiring index.js
 let rootState;
+function getVal(path = '') {
+  const parts = path.split('/').filter(Boolean);
+  let val = rootState;
+  for (const p of parts) {
+    val = val && val[p];
+  }
+  return val;
+}
 const mockDb = {
-  ref: jest.fn(() => ({
+  ref: jest.fn((path = '') => ({
     transaction: (update) => {
+      if (path) throw new Error('transaction only supported on root in mock');
       const res = update(rootState);
       if (res) {
         rootState = res;
         return {
           committed: true,
           snapshot: {
-            child: (path) => {
-              const parts = path.split('/');
-              let val = rootState;
-              for (const p of parts) {
-                val = val && val[p];
-              }
-              return { val: () => val };
-            },
+            child: (childPath) => ({
+              val: () => getVal(childPath),
+            }),
           },
         };
       }
@@ -27,6 +31,7 @@ const mockDb = {
         snapshot: { child: () => ({ val: () => undefined }) },
       };
     },
+    once: async () => ({ val: () => getVal(path) }),
   })),
 };
 
@@ -45,7 +50,7 @@ jest.mock('firebase-functions', () => ({
       }
     },
   },
-  logger: { error: jest.fn() },
+  logger: { error: jest.fn(), info: jest.fn() },
 }));
 
 const { purchaseItem } = require('../index');


### PR DESCRIPTION
## Summary
- log delta, offline earnings, and new score in `syncGubs`
- track score and cost for `purchaseItem`, logging details on failure and success
- log existing score and owned counts before running purchase transaction for deeper debugging
- extend tests to mock logger.info and database reads

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898d7ff09fc8323a00052294e81a2a0