### PR TITLE
Add detailed logging for gub sync and purchases

### DIFF
--- a/functions/__tests__/purchase-item.test.js
+++ b/functions/__tests__/purchase-item.test.js
@@ -2,31 +2,57 @@
 
 // Mock firebase-admin before requiring index.js
 let rootState;
+function getVal(path = '') {
+  const parts = path.split('/').filter(Boolean);
+  let val = rootState;
+  for (const p of parts) {
+    val = val && val[p];
+  }
+  return val;
+}
+function setVal(path = '', value) {
+  const parts = path.split('/').filter(Boolean);
+  if (parts.length === 0) {
+    rootState = value;
+    return;
+  }
+  let obj = rootState;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const p = parts[i];
+    obj[p] = obj[p] || {};
+    obj = obj[p];
+  }
+  obj[parts[parts.length - 1]] = value;
+}
+
 const mockDb = {
-  ref: jest.fn(() => ({
+  ref: jest.fn((path = '') => ({
     transaction: (update) => {
-      const res = update(rootState);
-      if (res) {
-        rootState = res;
+      const current = getVal(path);
+      const res = update(current);
+      if (res === undefined) {
         return {
-          committed: true,
+          committed: false,
           snapshot: {
-            child: (path) => {
-              const parts = path.split('/');
-              let val = rootState;
-              for (const p of parts) {
-                val = val && val[p];
-              }
-              return { val: () => val };
-            },
+            val: () => current,
+            child: (childPath) => ({
+              val: () => getVal(`${path}/${childPath}`),
+            }),
           },
         };
       }
+      setVal(path, res);
       return {
-        committed: false,
-        snapshot: { child: () => ({ val: () => undefined }) },
+        committed: true,
+        snapshot: {
+          val: () => getVal(path),
+          child: (childPath) => ({
+            val: () => getVal(`${path}/${childPath}`),
+          }),
+        },
       };
     },
+    once: async () => ({ val: () => getVal(path) }),
   })),
 };
 
@@ -45,7 +71,7 @@ jest.mock('firebase-functions', () => ({
       }
     },
   },
-  logger: { error: jest.fn() },
+  logger: { error: jest.fn(), info: jest.fn() },
 }));
 
 const { purchaseItem } = require('../index');


### PR DESCRIPTION
## Summary
- log delta, offline earnings, and new score in `syncGubs`
- track score and cost for `purchaseItem`, logging details on failure and success
- log existing score and owned counts before running purchase transaction for deeper debugging
- extend tests to mock logger.info and database reads
- refactor `purchaseItem` to avoid root-level transactions by targeting user score and item nodes separately

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898d7ff09fc8323a00052294e81a2a0