### PR TITLE
Handle concurrent gub syncs before purchases

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -187,50 +187,50 @@ window.addEventListener('DOMContentLoaded', () => {
         let gubRateMultiplier = 1;
         let scoreDirty = false;
 
-        let syncing = false;
+        let syncingPromise = null;
         async function syncGubsFromServer(requestOffline = false) {
-          if (syncing) return;
-          syncing = true;
+          if (syncingPromise) return syncingPromise;
           // Only sync whole gubs to avoid dropping fractional amounts
           const sendDelta = Math.floor(unsyncedDelta);
           unsyncedDelta -= sendDelta; // keep remainder locally
 
-          try {
-            const res = await syncGubsFn({
-              delta: sendDelta,
-              offline: requestOffline,
-            });
+          syncingPromise = (async () => {
+            try {
+              const res = await syncGubsFn({
+                delta: sendDelta,
+                offline: requestOffline,
+              });
 
-            if (res.data && typeof res.data.score === 'number') {
+              if (res.data && typeof res.data.score === 'number') {
+                const { score, offlineEarned = 0 } = res.data;
+                // Server stores integer scores, so re-add any local remainder
+                globalCount = displayedCount = score + unsyncedDelta;
+                renderCounter();
 
-              const { score, offlineEarned = 0 } = res.data;
-              // Server stores integer scores, so re-add any local remainder
-              globalCount = displayedCount = score + unsyncedDelta;
-              renderCounter();
-
-              if (requestOffline && !offlineShown && offlineEarned > 0) {
-
-                offlineMessage.textContent = `You earned ${abbreviateNumber(offlineEarned)} gubs while you were away!`;
-                offlineModal.style.display = 'block';
-
-                offlineShown = true;
+                if (requestOffline && !offlineShown && offlineEarned > 0) {
+                  offlineMessage.textContent = `You earned ${abbreviateNumber(offlineEarned)} gubs while you were away!`;
+                  offlineModal.style.display = 'block';
+                  offlineShown = true;
+                }
+              } else {
+                // Revert on failure to ensure no loss
+                unsyncedDelta += sendDelta;
               }
-            } else {
-              // Revert on failure to ensure no loss
+            } catch (err) {
               unsyncedDelta += sendDelta;
-            }
-          } catch (err) {
-            unsyncedDelta += sendDelta;
 
-            console.error('syncGubs failed', err);
-            logError(db, {
-              message: err.message,
-              stack: err.stack,
-              context: 'syncGubsFromServer',
-            });
-          } finally {
-            syncing = false;
-          }
+              console.error('syncGubs failed', err);
+              logError(db, {
+                message: err.message,
+                stack: err.stack,
+                context: 'syncGubsFromServer',
+              });
+            } finally {
+              syncingPromise = null;
+            }
+          })();
+
+          return syncingPromise;
         }
 
 


### PR DESCRIPTION
## Summary
- Ensure `syncGubsFromServer` returns a promise so callers wait for an in-flight sync
- Prevent purchases from using stale scores by awaiting ongoing gub syncs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898f1198eb08323a9b4f576c23d99fe