### PR TITLE
refactor: modularize main script

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,0 +1,17 @@
+export function initFirebase() {
+  const firebaseConfig = {
+    apiKey: 'AIzaSyBc2cDT3md2pk28dFMDoCeCgw37tpGBEjM',
+    authDomain: 'gub-leaderboard.firebaseapp.com',
+    databaseURL: 'https://gub-leaderboard-default-rtdb.firebaseio.com',
+    projectId: 'gub-leaderboard',
+    storageBucket: 'gub-leaderboard.firebasestorage.app',
+    messagingSenderId: '851465760203',
+    appId: '1:851465760203:web:1fc30c730a93c0fab25a4e',
+    measurementId: 'G-95SE4H7EEW',
+  };
+  firebase.initializeApp(firebaseConfig);
+  const auth = firebase.auth();
+  const db = firebase.database();
+  const functions = firebase.functions();
+  return { auth, db, functions };
+}

--- a/src/presence.js
+++ b/src/presence.js
@@ -1,0 +1,66 @@
+export function initPresenceAndLeaderboard({
+  db,
+  uid,
+  username,
+  sanitizeUsername,
+  allUsers,
+  CLIENT_VERSION,
+}) {
+  const versionRef = db.ref('config/version');
+  versionRef.on('value', (snap) => {
+    const serverVersion = snap.val();
+    if (serverVersion && serverVersion !== CLIENT_VERSION) {
+      const warn = document.createElement('div');
+      warn.textContent = 'Client outdated – refreshing in 5s...';
+      warn.style.cssText =
+        'position:fixed;top:0;left:0;width:100%;background:red;color:white;text-align:center;font-size:24px;padding:20px;z-index:100000;';
+      document.body.appendChild(warn);
+      setTimeout(() => location.reload(), 5000);
+    }
+  });
+
+  const presenceRef = db.ref('.info/connected');
+  const userOnlineRef = db.ref('presence/' + uid);
+
+  presenceRef.on('value', (snap) => {
+    if (snap.val() === true) {
+      userOnlineRef.set(username);
+      userOnlineRef.onDisconnect().remove();
+    }
+  });
+
+  const presenceListRef = db.ref('presence');
+  const onlineUsersEl = document.getElementById('online-users');
+  const onlineUsers = new Map();
+  const MAX_DISPLAY = 20;
+
+  function renderOnlineUsers() {
+    const arr = Array.from(onlineUsers.values());
+    const list = arr.slice(0, MAX_DISPLAY).join(', ');
+    const more =
+      arr.length > MAX_DISPLAY ? ` (+${arr.length - MAX_DISPLAY} more)` : '';
+    onlineUsersEl.textContent = `Online (${arr.length}): ${list}${more}`;
+  }
+
+  presenceListRef.on('child_added', (snap) => {
+    const name = sanitizeUsername(snap.val());
+    onlineUsers.set(snap.key, name);
+    allUsers.add(name);
+    renderOnlineUsers();
+  });
+
+  presenceListRef.on('child_removed', (snap) => {
+    onlineUsers.delete(snap.key);
+    renderOnlineUsers();
+  });
+
+  db.ref('leaderboard_v3')
+    .once('value')
+    .then((snap) => {
+      snap.forEach((child) => {
+        const data = child.val() || {};
+        const u = sanitizeUsername(data.username || '');
+        if (u) allUsers.add(u);
+      });
+    });
+}

--- a/src/shop.js
+++ b/src/shop.js
@@ -1,0 +1,284 @@
+export function initShop({
+  db,
+  uid,
+  purchaseItemFn,
+  syncGubsFromServer,
+  gameState,
+  renderCounter,
+  queueScoreUpdate,
+  abbreviateNumber,
+  passiveWorker,
+  logError,
+  sanitizeUsername,
+}) {
+  const COST_MULTIPLIER = 1.15; // smoother exponential cost scaling factor
+  const shopItems = [
+    { id: 'passiveMaker', name: 'The Gub', baseCost: 100, rate: 1 },
+    { id: 'guberator', name: 'Guberator', baseCost: 500, rate: 5 },
+    { id: 'gubmill', name: 'Gubmill', baseCost: 2000, rate: 20 },
+    {
+      id: 'gubsolar',
+      name: 'Solar Gub Panels',
+      baseCost: 10000,
+      rate: 100,
+    },
+    {
+      id: 'gubfactory',
+      name: 'Gubactory',
+      baseCost: 50000,
+      rate: 500,
+    },
+    {
+      id: 'gubhydro',
+      name: 'Hydro Gub Plant',
+      baseCost: 250000,
+      rate: 2500,
+    },
+    {
+      id: 'gubnuclear',
+      name: 'Nuclear Gub Plant',
+      baseCost: 1000000,
+      rate: 10000,
+    },
+    {
+      id: 'gubquantum',
+      name: 'Quantum Gub Computer',
+      baseCost: 5000000,
+      rate: 50000,
+    },
+    {
+      id: 'gubai',
+      name: 'GUB AI',
+      caption: '(be careful of gubnet...)',
+      baseCost: 25000000,
+      rate: 250000,
+    },
+    {
+      id: 'gubclone',
+      name: 'Gub Cloning Facility',
+      baseCost: 125000000,
+      rate: 1250000,
+    },
+    {
+      id: 'gubspace',
+      name: 'Gub Space Program',
+      baseCost: 625000000,
+      rate: 6250000,
+    },
+    {
+      id: 'intergalactic',
+      name: 'Intergalactic Gub',
+      baseCost: 3125000000,
+      rate: 31250000,
+    },
+  ];
+  const shopRef = db.ref(`shop_v2/${uid}`);
+  const owned = {
+    passiveMaker: 0,
+    guberator: 0,
+    gubmill: 0,
+    gubsolar: 0,
+    gubfactory: 0,
+    gubhydro: 0,
+    gubnuclear: 0,
+    gubquantum: 0,
+    gubai: 0,
+    gubclone: 0,
+    gubspace: 0,
+    intergalactic: 0,
+  };
+
+  function updatePassiveIncome() {
+    const perSecondTotal = shopItems.reduce(
+      (sum, item) => sum + owned[item.id] * item.rate,
+      0,
+    );
+    gameState.passiveRatePerSec = perSecondTotal;
+    passiveWorker.postMessage({ type: 'rate', value: gameState.passiveRatePerSec });
+    renderCounter();
+    queueScoreUpdate();
+  }
+
+  const shopBtn = document.getElementById('shopBtn');
+  const shopPanel = document.getElementById('shopPanel');
+  const shopContainer = document.getElementById('shopItemsContainer');
+  const adminBtn = document.getElementById('adminBtn');
+  const adminPanel = document.getElementById('adminPanel');
+  const adminUser = document.getElementById('adminUsername');
+  const adminScore = document.getElementById('adminScore');
+  const adminUpdate = document.getElementById('adminUpdate');
+  const adminDelete = document.getElementById('adminDelete');
+
+  const ADMIN_UIDS = [
+    'sGd1ZHR1nvMKKCw9A1O5bwtbFD23',
+    'YHtvs4JyAtS3SUtNAUJuPMm3ac22',
+  ];
+  db.ref('admins/' + uid)
+    .once('value')
+    .then((snap) => {
+      if (!snap.exists() && ADMIN_UIDS.includes(uid)) {
+        db.ref('admins/' + uid).set(true);
+        adminBtn.style.display = 'block';
+      } else if (snap.val()) {
+        adminBtn.style.display = 'block';
+      }
+    });
+
+  adminBtn.addEventListener('click', () => {
+    adminPanel.style.display =
+      adminPanel.style.display === 'block' ? 'none' : 'block';
+  });
+
+  adminUpdate.addEventListener('click', () => {
+    const target = sanitizeUsername(adminUser.value);
+    const score = parseInt(adminScore.value, 10);
+    if (!target || isNaN(score)) return;
+    db.ref('leaderboard_v3')
+      .orderByChild('username')
+      .equalTo(target)
+      .once('value')
+      .then((snap) => {
+        snap.forEach((child) => {
+          child.ref.update({ score });
+        });
+      });
+  });
+
+  adminDelete.addEventListener('click', () => {
+    const target = sanitizeUsername(adminUser.value);
+    if (!target) return;
+    db.ref('leaderboard_v3')
+      .orderByChild('username')
+      .equalTo(target)
+      .once('value')
+      .then((snap) => {
+        snap.forEach((child) => child.ref.remove());
+      });
+  });
+
+  shopBtn.addEventListener('click', () => {
+    shopPanel.style.display =
+      shopPanel.style.display === 'block' ? 'none' : 'block';
+  });
+
+  shopItems.forEach((item) => {
+    const div = document.createElement('div');
+    div.innerHTML = `
+    <strong>${item.name}</strong>${
+      item.caption
+        ? ` <span style="color:red;font-size:0.8em;">${item.caption}</span>`
+        : ''
+    }<br>
+    Cost: <span id="cost-${item.id}"></span> Gubs<br>
+    Rate: ${abbreviateNumber(item.rate)} Gub/s<br>
+    Owned: <span id="owned-${item.id}">0</span><br>
+    <button id="buy-${item.id}">Buy</button>
+    <button id="buy-${item.id}-x10">x10</button>
+    <button id="buy-${item.id}-x100">x100</button>
+    <button id="buy-${item.id}-all">All</button>
+    <hr style="border-color:#444">
+  `;
+    shopContainer.appendChild(div);
+
+    const buy1 = div.querySelector(`#buy-${item.id}`);
+    const buy10 = div.querySelector(`#buy-${item.id}-x10`);
+    const buy100 = div.querySelector(`#buy-${item.id}-x100`);
+    const buyAll = div.querySelector(`#buy-${item.id}-all`);
+    const costSpan = div.querySelector(`#cost-${item.id}`);
+
+    function currentCost() {
+      return Math.floor(
+        item.baseCost * Math.pow(COST_MULTIPLIER, owned[item.id]),
+      );
+    }
+
+    function totalCost(quantity) {
+      let cost = 0;
+      for (let i = 0; i < quantity; i++) {
+        cost += Math.floor(
+          item.baseCost * Math.pow(COST_MULTIPLIER, owned[item.id] + i),
+        );
+      }
+      return cost;
+    }
+
+    function updateCostDisplay() {
+      costSpan.textContent = abbreviateNumber(currentCost());
+    }
+
+    async function attemptPurchase(quantity) {
+      await syncGubsFromServer();
+      const cost = totalCost(quantity);
+      if (gameState.globalCount >= cost) {
+        try {
+          const res = await purchaseItemFn({
+            item: item.id,
+            quantity,
+          });
+          if (res.data) {
+            if (typeof res.data.owned === 'number') {
+              owned[item.id] = res.data.owned;
+              document.getElementById(`owned-${item.id}`).textContent =
+                owned[item.id];
+            }
+            if (typeof res.data.score === 'number') {
+              gameState.globalCount = gameState.displayedCount = res.data.score;
+              gameState.unsyncedDelta = 0;
+              renderCounter();
+            }
+          }
+          updatePassiveIncome();
+          updateCostDisplay();
+        } catch (err) {
+          console.error('purchaseItem failed', err);
+          logError(db, {
+            message: err.message,
+            stack: err.stack,
+            context: 'attemptPurchase',
+          });
+        }
+      }
+    }
+
+    function maxAffordable() {
+      let qty = 0;
+      let accumulated = 0;
+      while (true) {
+        const next = Math.floor(
+          item.baseCost * Math.pow(COST_MULTIPLIER, owned[item.id] + qty),
+        );
+        if (accumulated + next > gameState.globalCount) break;
+        accumulated += next;
+        qty++;
+      }
+      return qty;
+    }
+
+    buy1.addEventListener('click', () => attemptPurchase(1));
+    buy10.addEventListener('click', () => attemptPurchase(10));
+    buy100.addEventListener('click', () => attemptPurchase(100));
+    buyAll.addEventListener('click', () => {
+      const qty = maxAffordable();
+      if (qty > 0) attemptPurchase(qty);
+    });
+    updateCostDisplay();
+  });
+
+  shopRef.once('value').then((snapshot) => {
+    const stored = snapshot.val() || {};
+    shopItems.forEach((item) => {
+      owned[item.id] = stored[item.id] || 0;
+      document.getElementById(`owned-${item.id}`).textContent = owned[item.id];
+      const costSpan = document.getElementById(`cost-${item.id}`);
+      if (costSpan) {
+        costSpan.textContent = abbreviateNumber(
+          Math.floor(
+            item.baseCost * Math.pow(COST_MULTIPLIER, owned[item.id]),
+          ),
+        );
+      }
+    });
+    updatePassiveIncome();
+  });
+}
+

--- a/src/uiEffects.js
+++ b/src/uiEffects.js
@@ -1,0 +1,321 @@
+export function initUIEffects({ numFloaters: initialFloaters, audio, imageState }) {
+  const highImages = [
+    'floater1.jpg',
+    'floater2.jpg',
+    'floater3.jpg',
+    'floater4.png',
+    'floater5.jpg',
+    'floater6.jpg',
+    'floater7.jpg',
+    'floater8.jpg',
+    'floater9.jpg',
+    'floater10.jpg',
+    'floater11.jpg',
+    'floater12.jpg',
+    'floater13.jpg',
+    'floater14.jpg',
+    'floater15.jpg',
+    'floater16.jpg',
+    'floater17.png',
+    'floater18.jpg',
+  ];
+  const lowImages = [
+    'low_floater1.jpg',
+    'low_floater2.jpg',
+    'low_floater3.jpg',
+    'floater4.png',
+    'low_floater5.jpg',
+    'low_floater6.jpg',
+    'low_floater7.jpg',
+    'low_floater8.jpg',
+    'low_floater9.jpg',
+    'low_floater10.jpg',
+    'low_floater11.jpg',
+    'low_floater12.jpg',
+    'low_floater13.jpg',
+    'low_floater14.jpg',
+    'low_floater15.jpg',
+    'low_floater16.jpg',
+    'low_floater17.jpg',
+    'low_floater18.jpg',
+  ];
+  let useHighQuality = localStorage.getItem('gubHighQuality') === 'true';
+  let useComicSans = localStorage.getItem('gubComicSans') === 'true';
+  if (useComicSans) {
+    document.body.classList.add('comic-sans');
+  }
+  imageState.images = useHighQuality ? highImages : lowImages;
+  let images = imageState.images;
+  const texts = [
+    'bark',
+    'barke',
+    'gubbling',
+    'good boye',
+    'sniffa',
+    'shidded',
+    'gubb',
+    'gubbing',
+    "i'm gonna gub",
+    'he do be gubbin',
+    'were my salami go',
+    'Gub Gubtaro Pissboy420 Bong or Die',
+    'bork',
+    'aaaAAa',
+    'im gubbing it im gubbing it',
+    'bug',
+    'lil gublets',
+    'FUCKYOU BAILEY',
+    'ish true ish true',
+    'gub needs the funny 3 numbers on the back of ur credit card',
+  ];
+  let speedMultiplier = 2,
+    numFloaters = initialFloaters;
+  let movementPaused = false;
+  const floaters = [];
+
+  const savedSpeedStr = localStorage.getItem('gubSpeed');
+  const savedImagesStr = localStorage.getItem('gubImages');
+
+  if (savedSpeedStr !== null) {
+    const parsedSpeed = parseInt(savedSpeedStr, 10);
+    if (!Number.isNaN(parsedSpeed)) {
+      speedMultiplier = parsedSpeed;
+    }
+  }
+
+  if (savedImagesStr !== null) {
+    const parsedImages = parseInt(savedImagesStr, 10);
+    if (!Number.isNaN(parsedImages)) {
+      numFloaters = parsedImages;
+    }
+  }
+
+  movementPaused = localStorage.getItem('gubPaused') === 'true';
+  let storedSpeed = speedMultiplier;
+  if (movementPaused) {
+    speedMultiplier = 0;
+  }
+  function createEntity(isText = false) {
+    const elem = document.createElement('div');
+    const size = 80 + Math.random() * 320;
+    elem.style.width = elem.style.height = size + 'px';
+    elem.style.left = Math.random() * (window.innerWidth - size) + 'px';
+    elem.style.top = Math.random() * (window.innerHeight - size) + 'px';
+    let imgIdx = null;
+    if (isText) {
+      elem.className = 'rainbow-text';
+      elem.textContent = texts[Math.floor(Math.random() * texts.length)];
+    } else {
+      elem.className = 'floater';
+      const img = document.createElement('img');
+      imgIdx = Math.floor(Math.random() * images.length);
+      img.src = images[imgIdx];
+      elem.appendChild(img);
+    }
+    document.body.appendChild(elem);
+    floaters.push({
+      elem,
+      x: parseFloat(elem.style.left),
+      y: parseFloat(elem.style.top),
+      vx: (Math.random() - 0.5) * 2,
+      vy: (Math.random() - 0.5) * 2,
+      width: size,
+      height: size,
+      isText,
+      imgIdx,
+    });
+  }
+  function removeEntity() {
+    const f = floaters.pop();
+    if (f) f.elem.remove();
+  }
+  function animate() {
+    floaters.forEach((f) => {
+      f.x += f.vx * speedMultiplier;
+      f.y += f.vy * speedMultiplier;
+      if (f.x <= 0 || f.x + f.width >= window.innerWidth) f.vx *= -1;
+      if (f.y <= 0 || f.y + f.height >= window.innerHeight) f.vy *= -1;
+      f.elem.style.left = f.x + 'px';
+      f.elem.style.top = f.y + 'px';
+    });
+    requestAnimationFrame(animate);
+  }
+  for (let i = 0; i < numFloaters; i++) {
+    createEntity(false);
+    createEntity(true);
+  }
+  animate();
+  // Controls
+  const settingsBtn = document.getElementById('lowPerfBtn');
+  const perfMenu = document.getElementById('perfMenu');
+  const spdDec = document.getElementById('spdDec');
+  const spdInc = document.getElementById('spdInc');
+  const imgDec = document.getElementById('imgDec');
+  const imgInc = document.getElementById('imgInc');
+  const spdVal = document.getElementById('spdVal');
+  const imgVal = document.getElementById('imgVal');
+  const moveToggle = document.getElementById('moveToggle');
+  const qualityBtn = document.getElementById('qualityBtn');
+  const comicBtn = document.getElementById('comicBtn');
+  qualityBtn.textContent = useHighQuality
+    ? 'High Quality: On'
+    : 'High Quality: Off';
+  comicBtn.textContent = useComicSans ? 'Comic Sans: On' : 'Comic Sans: Off';
+  qualityBtn.onclick = () => {
+    useHighQuality = !useHighQuality;
+    localStorage.setItem('gubHighQuality', useHighQuality);
+    imageState.images = images = useHighQuality ? highImages : lowImages;
+    qualityBtn.textContent = useHighQuality
+      ? 'High Quality: On'
+      : 'High Quality: Off';
+    floaters.forEach((f) => {
+      if (!f.isText && f.imgIdx !== null) {
+        const img = f.elem.querySelector('img');
+        img.src = images[f.imgIdx];
+      }
+    });
+  };
+  comicBtn.onclick = () => {
+    useComicSans = !useComicSans;
+    document.body.classList.toggle('comic-sans', useComicSans);
+    comicBtn.textContent = useComicSans
+      ? 'Comic Sans: On'
+      : 'Comic Sans: Off';
+    localStorage.setItem('gubComicSans', useComicSans);
+  };
+
+  settingsBtn.onclick = () => {
+    perfMenu.style.display =
+      perfMenu.style.display === 'block' ? 'none' : 'block';
+  };
+  function updateLabels() {
+    spdVal.textContent = speedMultiplier;
+    imgVal.textContent = numFloaters;
+  }
+  function adjustSpeed(d) {
+    if (movementPaused) {
+      storedSpeed = Math.max(1, storedSpeed + d);
+      localStorage.setItem('gubSpeed', storedSpeed);
+    } else {
+      speedMultiplier = Math.max(1, speedMultiplier + d);
+      localStorage.setItem('gubSpeed', speedMultiplier);
+    }
+    updateLabels();
+  }
+  function adjustImages(d) {
+    const newVal = Math.max(0, numFloaters + d);
+    if (newVal !== numFloaters) {
+      if (d > 0)
+        for (let i = 0; i < d; i++) {
+          createEntity(false);
+          createEntity(true);
+        }
+      else
+        for (let i = 0; i < -d; i++) {
+          removeEntity();
+          removeEntity();
+        }
+      numFloaters = newVal;
+      localStorage.setItem('gubImages', numFloaters);
+      updateLabels();
+    }
+  }
+  spdDec.onclick = () => adjustSpeed(-1);
+  spdInc.onclick = () => adjustSpeed(1);
+  imgDec.onclick = () => adjustImages(-2);
+  imgInc.onclick = () => adjustImages(2);
+  moveToggle.onclick = () => {
+    if (!movementPaused) {
+      storedSpeed = speedMultiplier;
+      speedMultiplier = 0;
+      moveToggle.textContent = 'Resume Movement';
+    } else {
+      speedMultiplier = storedSpeed;
+      moveToggle.textContent = 'Pause Movement';
+    }
+    movementPaused = !movementPaused;
+    localStorage.setItem('gubPaused', movementPaused);
+    localStorage.setItem('gubSpeed', storedSpeed);
+    updateLabels();
+  };
+
+  if (movementPaused) {
+    moveToggle.textContent = 'Resume Movement';
+  }
+  updateLabels();
+
+  // Twitch & Chaos Mode
+  const chaosBtn = document.getElementById('chaosBtn');
+  const twitchBtn = document.getElementById('twitchBtn');
+  const twitchBox = document.getElementById('twitchPlayer');
+  twitchBox.style.display = 'block';
+  twitchBox.style.visibility = 'hidden';
+  const twitchEmbed = new Twitch.Embed('twitchPlayer', {
+    width: '100%',
+    height: '100%',
+    channel: 'harupi',
+    layout: 'video',
+    parent: [location.hostname],
+    autoplay: false,
+    muted: true,
+  });
+  let twitchPlayer;
+  twitchEmbed.addEventListener(Twitch.Embed.VIDEO_READY, () => {
+    twitchPlayer = twitchEmbed.getPlayer();
+    twitchPlayer.setMuted(true);
+  });
+  let twitchShown = false;
+
+  twitchBtn.onclick = () => {
+    if (!twitchShown) {
+      twitchBox.style.visibility = 'visible';
+      twitchPlayer && twitchPlayer.play();
+      twitchBtn.textContent = 'Hide Stream';
+    } else {
+      twitchPlayer && twitchPlayer.pause();
+      twitchBox.style.visibility = 'hidden';
+      twitchBtn.textContent = 'Show Stream';
+    }
+    twitchShown = !twitchShown;
+  };
+
+  chaosBtn.addEventListener('click', () => {
+    audio.state.flashing = !audio.state.flashing;
+
+    floaters.forEach((f) => {
+      const dur = (0.3 + Math.random() * 0.7).toFixed(2);
+      const dir = Math.random() > 0.5 ? 'alternate' : 'alternate-reverse';
+      const ease = Math.random() > 0.5 ? 'ease-in' : 'ease-out';
+      if (audio.state.flashing) {
+        // turn ON chaos: add animations
+        if (f.elem.classList.contains('rainbow-text')) {
+          f.elem.style.animation = `rainbow 5s linear infinite, spinmove ${dur}s infinite ${dir} ${ease}`;
+        } else {
+          f.elem.style.animation = `spinmove ${dur}s infinite ${dir} ${ease}`;
+        }
+      } else {
+        // turn OFF chaos: remove any animation
+        f.elem.style.animation = '';
+      }
+    });
+
+    if (audio.state.flashing) {
+      document.body.style.animation = 'flash 0.1s infinite alternate';
+      if (audio.audioCtx.state === 'suspended') audio.audioCtx.resume();
+      if (!audio.state.musicPlaying) {
+        audio.chaosAudio.play().catch(() => {});
+        audio.state.musicPlaying = true;
+      }
+    } else {
+      document.body.style.animation = 'none';
+      audio.chaosAudio.pause();
+      audio.state.musicPlaying = false;
+    }
+    updateLabels();
+  });
+
+  const styleEl = document.createElement('style');
+  styleEl.textContent = `@keyframes flash{0%{background:#111}25%{background:#ff0}50%{background:#0ff}75%{background:#f0f}100%{background:#111}}@keyframes spinmove{0%{transform:scale(1) rotate(0deg)}50%{transform:scale(1.2) rotate(180deg)}100%{transform:scale(1) rotate(360deg)}}`;
+  document.head.appendChild(styleEl);
+}
+


### PR DESCRIPTION
## Summary
- extract Firebase initialization into `initFirebase`
- move presence/leaderboard logic to `initPresenceAndLeaderboard`
- shift shop handling to `initShop`
- isolate UI animation and controls via `initUIEffects`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898d6cdf99c8323a0d44f0d42ccc4a7