### PR TITLE
Refactor server functions with shared config and validation

### DIFF
--- a/functions/__tests__/purchase-item.test.js
+++ b/functions/__tests__/purchase-item.test.js
@@ -35,7 +35,6 @@ const mockDb = {
         return {
           committed: false,
           snapshot: {
-
             val: () => current,
             child: (childPath) => ({
               val: () => getVal(`${path}/${childPath}`),
@@ -93,5 +92,13 @@ describe('purchaseItem', () => {
     expect(result).toEqual({ score: 36, owned: 2 });
     expect(rootState.shop_v2[uid].passiveMaker).toBe(2);
     expect(rootState.leaderboard_v3[uid].score).toBe(36);
+  });
+
+  test('rejects unknown shop items', async () => {
+    const uid = 'user2';
+    rootState = { leaderboard_v3: { [uid]: { score: 1000 } }, shop_v2: {} };
+    await expect(
+      purchaseItem({ item: 'nope', quantity: 1 }, { auth: { uid } }),
+    ).rejects.toHaveProperty('code', 'invalid-argument');
   });
 });

--- a/functions/config.js
+++ b/functions/config.js
@@ -1,0 +1,33 @@
+const RATES = {
+  passiveMaker: 1,
+  guberator: 5,
+  gubmill: 20,
+  gubsolar: 100,
+  gubfactory: 500,
+  gubhydro: 2500,
+  gubnuclear: 10000,
+  gubquantum: 50000,
+  gubai: 250000,
+  gubclone: 1250000,
+  gubspace: 6250000,
+  intergalactic: 31250000,
+};
+
+const COST_MULTIPLIER = 1.15;
+
+const SHOP_ITEMS = {
+  passiveMaker: 100,
+  guberator: 500,
+  gubmill: 2000,
+  gubsolar: 10000,
+  gubfactory: 50000,
+  gubhydro: 250000,
+  gubnuclear: 1000000,
+  gubquantum: 5000000,
+  gubai: 25000000,
+  gubclone: 125000000,
+  gubspace: 625000000,
+  intergalactic: 3125000000,
+};
+
+module.exports = { RATES, COST_MULTIPLIER, SHOP_ITEMS };

--- a/functions/validation.js
+++ b/functions/validation.js
@@ -1,0 +1,19 @@
+const functions = require('firebase-functions');
+const { SHOP_ITEMS } = require('./config');
+
+function validateSyncGubs(data = {}) {
+  const delta = typeof data.delta === 'number' ? Math.floor(data.delta) : 0;
+  const requestOffline = Boolean(data.offline);
+  return { delta, requestOffline };
+}
+
+function validatePurchaseItem(data = {}) {
+  const item = data.item;
+  if (!SHOP_ITEMS[item]) {
+    throw new functions.https.HttpsError('invalid-argument', 'Unknown item');
+  }
+  const quantity = Math.max(1, Math.floor(Number(data.quantity || 1)));
+  return { item, quantity };
+}
+
+module.exports = { validateSyncGubs, validatePurchaseItem };


### PR DESCRIPTION
## Summary
- centralize shop items, rates, and cost multiplier in a new shared config module
- add reusable validation helpers and integrate into syncGubs and purchaseItem
- cover invalid shop item requests with a unit test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898f972a3e88323b1c99d9e0ac03fa4