### PR TITLE
Validate purchase quantities and add tests

### DIFF
--- a/functions/__tests__/purchase-item.test.js
+++ b/functions/__tests__/purchase-item.test.js
@@ -101,4 +101,31 @@ describe('purchaseItem', () => {
       purchaseItem({ item: 'nope', quantity: 1 }, { auth: { uid } }),
     ).rejects.toHaveProperty('code', 'invalid-argument');
   });
+
+  test('rejects quantities over limit', async () => {
+    const uid = 'user3';
+    rootState = { leaderboard_v3: { [uid]: { score: 1000 } }, shop_v2: {} };
+    await expect(
+      purchaseItem({ item: 'passiveMaker', quantity: 1001 }, { auth: { uid } }),
+    ).rejects.toHaveProperty('code', 'invalid-argument');
+  });
+
+  test('rejects negative quantities', async () => {
+    const uid = 'user4';
+    rootState = { leaderboard_v3: { [uid]: { score: 1000 } }, shop_v2: {} };
+    await expect(
+      purchaseItem({ item: 'passiveMaker', quantity: -5 }, { auth: { uid } }),
+    ).rejects.toHaveProperty('code', 'invalid-argument');
+  });
+
+  test('rejects non-numeric quantities', async () => {
+    const uid = 'user5';
+    rootState = { leaderboard_v3: { [uid]: { score: 1000 } }, shop_v2: {} };
+    await expect(
+      purchaseItem(
+        { item: 'passiveMaker', quantity: 'abc' },
+        { auth: { uid } },
+      ),
+    ).rejects.toHaveProperty('code', 'invalid-argument');
+  });
 });

--- a/functions/validation.js
+++ b/functions/validation.js
@@ -12,7 +12,21 @@ function validatePurchaseItem(data = {}) {
   if (!SHOP_ITEMS[item]) {
     throw new functions.https.HttpsError('invalid-argument', 'Unknown item');
   }
-  const quantity = Math.max(1, Math.floor(Number(data.quantity || 1)));
+  const rawQuantity = data.quantity ?? 1;
+  const numQuantity = Number(rawQuantity);
+  if (!Number.isFinite(numQuantity)) {
+    throw new functions.https.HttpsError(
+      'invalid-argument',
+      'Invalid quantity',
+    );
+  }
+  const quantity = Math.floor(numQuantity);
+  if (quantity < 1 || quantity > 1000) {
+    throw new functions.https.HttpsError(
+      'invalid-argument',
+      'Quantity must be between 1 and 1000',
+    );
+  }
   return { item, quantity };
 }
 


### PR DESCRIPTION
## Summary
- Validate shop purchase quantity is a finite number between 1 and 1000
- Provide clearer error messaging for invalid quantity inputs
- Add tests for large, negative, and non-numeric purchase quantities

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689905d8e3708323b053806eadaaeefa