### PR TITLE
refactor: centralize shop config and cost utils

### DIFF
--- a/functions/__tests__/offline.test.js
+++ b/functions/__tests__/offline.test.js
@@ -1,5 +1,5 @@
-/* eslint-env jest */
-const { calculateOfflineGubs } = require('../offline');
+import { describe, test, expect } from '@jest/globals';
+import { calculateOfflineGubs } from '../offline.js';
 
 describe('calculateOfflineGubs', () => {
   test('awards 25% of rate per second of elapsed time', () => {

--- a/functions/__tests__/purchase-item.test.js
+++ b/functions/__tests__/purchase-item.test.js
@@ -1,6 +1,5 @@
-/* eslint-env jest */
+import { describe, test, expect, jest } from '@jest/globals';
 
-// Mock firebase-admin before requiring index.js
 let rootState;
 function getVal(path = '') {
   const parts = path.split('/').filter(Boolean);
@@ -57,12 +56,11 @@ const mockDb = {
   })),
 };
 
-jest.mock('firebase-admin', () => ({
-  initializeApp: jest.fn(),
-  database: () => mockDb,
+jest.unstable_mockModule('firebase-admin', () => ({
+  default: { initializeApp: jest.fn(), database: () => mockDb },
 }));
 
-jest.mock('firebase-functions', () => ({
+jest.unstable_mockModule('firebase-functions', () => ({
   https: {
     onCall: (fn) => fn,
     HttpsError: class extends Error {
@@ -75,7 +73,7 @@ jest.mock('firebase-functions', () => ({
   logger: { error: jest.fn(), info: jest.fn() },
 }));
 
-const { purchaseItem } = require('../index');
+const { purchaseItem } = await import('../index.js');
 
 describe('purchaseItem', () => {
   test('handles owned values stored as strings', async () => {

--- a/functions/config.js
+++ b/functions/config.js
@@ -1,33 +1,9 @@
-const RATES = {
-  passiveMaker: 1,
-  guberator: 5,
-  gubmill: 20,
-  gubsolar: 100,
-  gubfactory: 500,
-  gubhydro: 2500,
-  gubnuclear: 10000,
-  gubquantum: 50000,
-  gubai: 250000,
-  gubclone: 1250000,
-  gubspace: 6250000,
-  intergalactic: 31250000,
-};
+import shopConfig from '../shared/shop-config.js';
 
-const COST_MULTIPLIER = 1.15;
-
-const SHOP_ITEMS = {
-  passiveMaker: 100,
-  guberator: 500,
-  gubmill: 2000,
-  gubsolar: 10000,
-  gubfactory: 50000,
-  gubhydro: 250000,
-  gubnuclear: 1000000,
-  gubquantum: 5000000,
-  gubai: 25000000,
-  gubclone: 125000000,
-  gubspace: 625000000,
-  intergalactic: 3125000000,
-};
-
-module.exports = { RATES, COST_MULTIPLIER, SHOP_ITEMS };
+export const COST_MULTIPLIER = shopConfig.costMultiplier;
+export const SHOP_ITEMS = Object.fromEntries(
+  shopConfig.items.map((item) => [item.id, item.baseCost]),
+);
+export const RATES = Object.fromEntries(
+  shopConfig.items.map((item) => [item.id, item.rate]),
+);

--- a/functions/offline.js
+++ b/functions/offline.js
@@ -1,9 +1,7 @@
 const OFFLINE_RATE = 0.25; // earn 25% of passive rate while offline
 
-function calculateOfflineGubs(rate, lastUpdated, now = Date.now()) {
+export function calculateOfflineGubs(rate, lastUpdated, now = Date.now()) {
   const elapsed = Math.max(0, now - lastUpdated); // milliseconds
   const earned = rate * OFFLINE_RATE * (elapsed / 1000); // 25% of rate per second
   return Math.floor(earned);
 }
-
-module.exports = { calculateOfflineGubs };

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,6 +2,7 @@
   "name": "functions",
   "description": "Cloud Functions for gub-gub-site",
   "main": "index.js",
+  "type": "module",
   "engines": {
     "node": "18"
   },

--- a/functions/validation.js
+++ b/functions/validation.js
@@ -1,13 +1,13 @@
-const functions = require('firebase-functions');
-const { SHOP_ITEMS } = require('./config');
+import * as functions from 'firebase-functions';
+import { SHOP_ITEMS } from './config.js';
 
-function validateSyncGubs(data = {}) {
+export function validateSyncGubs(data = {}) {
   const delta = typeof data.delta === 'number' ? Math.floor(data.delta) : 0;
   const requestOffline = Boolean(data.offline);
   return { delta, requestOffline };
 }
 
-function validatePurchaseItem(data = {}) {
+export function validatePurchaseItem(data = {}) {
   const item = data.item;
   if (!SHOP_ITEMS[item]) {
     throw new functions.https.HttpsError('invalid-argument', 'Unknown item');
@@ -30,7 +30,7 @@ function validatePurchaseItem(data = {}) {
   return { item, quantity };
 }
 
-function validateAdminUpdate(data = {}) {
+export function validateAdminUpdate(data = {}) {
   const username =
     typeof data.username === 'string' ? data.username.trim() : '';
   const score = Number.isInteger(data.score)
@@ -48,7 +48,7 @@ function validateAdminUpdate(data = {}) {
   return { username, score };
 }
 
-function validateAdminDelete(data = {}) {
+export function validateAdminDelete(data = {}) {
   const username =
     typeof data.username === 'string' ? data.username.trim() : '';
   if (!username || !/^[A-Za-z0-9_]{3,20}$/.test(username)) {
@@ -59,10 +59,3 @@ function validateAdminDelete(data = {}) {
   }
   return { username };
 }
-
-module.exports = {
-  validateSyncGubs,
-  validatePurchaseItem,
-  validateAdminUpdate,
-  validateAdminDelete,
-};

--- a/shared/cost.js
+++ b/shared/cost.js
@@ -1,0 +1,25 @@
+export function currentCost(baseCost, owned, multiplier) {
+  return Math.floor(baseCost * Math.pow(multiplier, owned));
+}
+
+export function totalCost(baseCost, owned, quantity, multiplier) {
+  let cost = 0;
+  for (let i = 0; i < quantity; i++) {
+    cost += currentCost(baseCost, owned + i, multiplier);
+  }
+  return cost;
+}
+
+export function maxAffordable(baseCost, owned, available, multiplier) {
+  let qty = 0;
+  let accumulated = 0;
+  while (true) {
+    const next = currentCost(baseCost, owned + qty, multiplier);
+    if (accumulated + next > available) break;
+    accumulated += next;
+    qty++;
+  }
+  return qty;
+}
+
+export default { currentCost, totalCost, maxAffordable };

--- a/shared/shop-config.js
+++ b/shared/shop-config.js
@@ -1,0 +1,48 @@
+export default {
+  costMultiplier: 1.15,
+  items: [
+    { id: 'passiveMaker', name: 'The Gub', baseCost: 100, rate: 1 },
+    { id: 'guberator', name: 'Guberator', baseCost: 500, rate: 5 },
+    { id: 'gubmill', name: 'Gubmill', baseCost: 2000, rate: 20 },
+    { id: 'gubsolar', name: 'Solar Gub Panels', baseCost: 10000, rate: 100 },
+    { id: 'gubfactory', name: 'Gubactory', baseCost: 50000, rate: 500 },
+    { id: 'gubhydro', name: 'Hydro Gub Plant', baseCost: 250000, rate: 2500 },
+    {
+      id: 'gubnuclear',
+      name: 'Nuclear Gub Plant',
+      baseCost: 1000000,
+      rate: 10000,
+    },
+    {
+      id: 'gubquantum',
+      name: 'Quantum Gub Computer',
+      baseCost: 5000000,
+      rate: 50000,
+    },
+    {
+      id: 'gubai',
+      name: 'GUB AI',
+      caption: '(be careful of gubnet...)',
+      baseCost: 25000000,
+      rate: 250000,
+    },
+    {
+      id: 'gubclone',
+      name: 'Gub Cloning Facility',
+      baseCost: 125000000,
+      rate: 1250000,
+    },
+    {
+      id: 'gubspace',
+      name: 'Gub Space Program',
+      baseCost: 625000000,
+      rate: 6250000,
+    },
+    {
+      id: 'intergalactic',
+      name: 'Intergalactic Gub',
+      baseCost: 3125000000,
+      rate: 31250000,
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- share shop config across client and Firebase functions
- add cost calculation helper for current, total and affordable costs
- update shop and functions to use shared helpers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68990981fde88323bf3b885b728f95f8