### PR TITLE
fix: resolve cost util path for functions

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -8,7 +8,7 @@ import {
   validateAdminUpdate,
   validateAdminDelete,
 } from './validation.js';
-import { totalCost } from '../shared/cost.js';
+import { totalCost } from './shared/cost.js';
 
 admin.initializeApp();
 

--- a/functions/shared/cost.js
+++ b/functions/shared/cost.js
@@ -1,0 +1,25 @@
+export function currentCost(baseCost, owned, multiplier) {
+  return Math.floor(baseCost * Math.pow(multiplier, owned));
+}
+
+export function totalCost(baseCost, owned, quantity, multiplier) {
+  let cost = 0;
+  for (let i = 0; i < quantity; i++) {
+    cost += currentCost(baseCost, owned + i, multiplier);
+  }
+  return cost;
+}
+
+export function maxAffordable(baseCost, owned, available, multiplier) {
+  let qty = 0;
+  let accumulated = 0;
+  while (true) {
+    const next = currentCost(baseCost, owned + qty, multiplier);
+    if (accumulated + next > available) break;
+    accumulated += next;
+    qty++;
+  }
+  return qty;
+}
+
+export default { currentCost, totalCost, maxAffordable };


### PR DESCRIPTION
## Summary
- copy shared cost helper into `functions/shared`
- update Cloud Functions to import `./shared/cost.js`

## Testing
- `npm test`
- `npm run lint` *(fails: prettier/prettier in functions/__tests__/sync-gubs.test.js)*
- `firebase --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6899119e68a4832398c7bde3280281e4