### PR TITLE
refactor: centralize auth check

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -18,214 +18,216 @@ async function isAdmin(uid) {
   return snap.val() === true;
 }
 
-export const syncGubs = functions.https.onCall(async (data, ctx) => {
-  const uid = ctx.auth?.uid;
-  if (!uid) {
-    throw new functions.https.HttpsError('unauthenticated');
-  }
-  try {
-    const { delta, requestOffline } = validateSyncGubs(data);
+function withAuth(handler) {
+  return async (data, ctx) => {
+    const uid = ctx.auth?.uid;
+    if (!uid) {
+      throw new functions.https.HttpsError('unauthenticated');
+    }
+    return handler(uid, data, ctx);
+  };
+}
 
-    const db = admin.database();
-    const userRef = db.ref(`leaderboard_v3/${uid}`);
-    const shop = (await db.ref(`shop_v2/${uid}`).once('value')).val() || {};
-    const rate = Object.entries(shop).reduce(
-      (sum, [k, v]) => sum + (RATES[k] || 0) * v,
-      0,
-    );
+export const syncGubs = functions.https.onCall(
+  withAuth(async (uid, data) => {
+    try {
+      const { delta, requestOffline } = validateSyncGubs(data);
 
-    let offlineEarned = 0;
-    const now = Date.now();
-    const result = await userRef.transaction((user) => {
-      user = user || {};
-      const { score = 0, lastUpdated = now } = user;
-      if (requestOffline) {
-        offlineEarned = calculateOfflineGubs(rate, lastUpdated, now);
-      }
-      return {
-        ...user,
-        score: score + delta + offlineEarned,
-        lastUpdated: now,
-      };
-    });
-    const newScore = result.snapshot.child('score').val() || 0;
-    functions.logger.info('syncGubs', {
-      uid,
-      delta,
-      offlineEarned,
-      newScore,
-    });
-    return { score: newScore, offlineEarned };
-  } catch (err) {
-    await logError('server', err, { function: 'syncGubs', uid, data });
-    throw err;
-  }
-});
+      const db = admin.database();
+      const userRef = db.ref(`leaderboard_v3/${uid}`);
+      const shop = (await db.ref(`shop_v2/${uid}`).once('value')).val() || {};
+      const rate = Object.entries(shop).reduce(
+        (sum, [k, v]) => sum + (RATES[k] || 0) * v,
+        0,
+      );
 
-export const purchaseItem = functions.https.onCall(async (data, ctx) => {
-  const uid = ctx.auth?.uid;
-  if (!uid) {
-    throw new functions.https.HttpsError('unauthenticated');
-  }
-  let item, quantity;
-  try {
-    ({ item, quantity } = validatePurchaseItem(data));
-    const db = admin.database();
-    // Log current values before attempting the transaction so we can compare
-    // what the transaction sees versus what's stored in the database.
-    const [preScoreSnap, preOwnedSnap] = await Promise.all([
-      db.ref(`leaderboard_v3/${uid}/score`).once('value'),
-      db.ref(`shop_v2/${uid}/${item}`).once('value'),
-    ]);
-    const preScore = Number(preScoreSnap.val()) || 0;
-    const preOwned = Number(preOwnedSnap.val()) || 0;
-    functions.logger.info('purchaseItem.precheck', {
-      uid,
-      item,
-      score: preScore,
-      owned: preOwned,
-    });
-
-    // Calculate cost based on pre-transaction values
-    const cost = totalCost(
-      SHOP_ITEMS[item],
-      preOwned,
-      quantity,
-      COST_MULTIPLIER,
-    );
-
-    // Ensure the user's recorded score meets the cost before attempting
-    // the transactional deduction to avoid unnecessary retries
-    if (preScore < cost) {
-      await logError('server', new Error('Not enough gubs'), {
-        function: 'purchaseItem',
+      let offlineEarned = 0;
+      const now = Date.now();
+      const result = await userRef.transaction((user) => {
+        user = user || {};
+        const { score = 0, lastUpdated = now } = user;
+        if (requestOffline) {
+          offlineEarned = calculateOfflineGubs(rate, lastUpdated, now);
+        }
+        return {
+          ...user,
+          score: score + delta + offlineEarned,
+          lastUpdated: now,
+        };
+      });
+      const newScore = result.snapshot.child('score').val() || 0;
+      functions.logger.info('syncGubs', {
         uid,
-        data,
+        delta,
+        offlineEarned,
+        newScore,
+      });
+      return { score: newScore, offlineEarned };
+    } catch (err) {
+      await logError('server', err, { function: 'syncGubs', uid, data });
+      throw err;
+    }
+  }),
+);
+
+export const purchaseItem = functions.https.onCall(
+  withAuth(async (uid, data) => {
+    let item, quantity;
+    try {
+      ({ item, quantity } = validatePurchaseItem(data));
+      const db = admin.database();
+      // Log current values before attempting the transaction so we can compare
+      // what the transaction sees versus what's stored in the database.
+      const [preScoreSnap, preOwnedSnap] = await Promise.all([
+        db.ref(`leaderboard_v3/${uid}/score`).once('value'),
+        db.ref(`shop_v2/${uid}/${item}`).once('value'),
+      ]);
+      const preScore = Number(preScoreSnap.val()) || 0;
+      const preOwned = Number(preOwnedSnap.val()) || 0;
+      functions.logger.info('purchaseItem.precheck', {
+        uid,
+        item,
         score: preScore,
-        cost,
         owned: preOwned,
       });
-      throw new functions.https.HttpsError(
-        'failed-precondition',
-        `Not enough gubs: have ${preScore}, need ${cost}`,
+
+      // Calculate cost based on pre-transaction values
+      const cost = totalCost(
+        SHOP_ITEMS[item],
+        preOwned,
+        quantity,
+        COST_MULTIPLIER,
       );
-    }
 
-    let availableScore = 0;
-    const userRef = db.ref(`leaderboard_v3/${uid}`);
-    const scoreResult = await userRef.transaction((user) => {
-      user = user || {};
-      const currentScore = Number(user.score) || 0;
-      availableScore = currentScore;
-      if (currentScore < cost) return; // abort
-      return {
-        ...user,
-        score: currentScore - cost,
-        lastUpdated: Date.now(),
-      };
-    });
+      // Ensure the user's recorded score meets the cost before attempting
+      // the transactional deduction to avoid unnecessary retries
+      if (preScore < cost) {
+        await logError('server', new Error('Not enough gubs'), {
+          function: 'purchaseItem',
+          uid,
+          data,
+          score: preScore,
+          cost,
+          owned: preOwned,
+        });
+        throw new functions.https.HttpsError(
+          'failed-precondition',
+          `Not enough gubs: have ${preScore}, need ${cost}`,
+        );
+      }
 
-    if (!scoreResult.committed) {
-      await logError('server', new Error('Not enough gubs'), {
-        function: 'purchaseItem',
+      let availableScore = 0;
+      const userRef = db.ref(`leaderboard_v3/${uid}`);
+      const scoreResult = await userRef.transaction((user) => {
+        user = user || {};
+        const currentScore = Number(user.score) || 0;
+        availableScore = currentScore;
+        if (currentScore < cost) return; // abort
+        return {
+          ...user,
+          score: currentScore - cost,
+          lastUpdated: Date.now(),
+        };
+      });
+
+      if (!scoreResult.committed) {
+        await logError('server', new Error('Not enough gubs'), {
+          function: 'purchaseItem',
+          uid,
+          data,
+          score: availableScore,
+          cost,
+          owned: preOwned,
+        });
+        throw new functions.https.HttpsError(
+          'failed-precondition',
+          `Not enough gubs: have ${availableScore}, need ${cost}`,
+        );
+      }
+
+      const newScore = scoreResult.snapshot.child('score').val() || 0;
+
+      const ownedResult = await db
+        .ref(`shop_v2/${uid}/${item}`)
+        .transaction((curr) => (Number(curr) || 0) + quantity);
+
+      const newOwned = Number(ownedResult.snapshot.val()) || 0;
+      functions.logger.info('purchaseItem', {
         uid,
-        data,
-        score: availableScore,
+        item,
+        quantity,
+
         cost,
-        owned: preOwned,
+        score: newScore,
+        owned: newOwned,
       });
-      throw new functions.https.HttpsError(
-        'failed-precondition',
-        `Not enough gubs: have ${availableScore}, need ${cost}`,
-      );
+      return { score: newScore, owned: newOwned };
+    } catch (err) {
+      await logError('server', err, { function: 'purchaseItem', uid, data });
+      throw err;
     }
+  }),
+);
 
-    const newScore = scoreResult.snapshot.child('score').val() || 0;
-
-    const ownedResult = await db
-      .ref(`shop_v2/${uid}/${item}`)
-      .transaction((curr) => (Number(curr) || 0) + quantity);
-
-    const newOwned = Number(ownedResult.snapshot.val()) || 0;
-    functions.logger.info('purchaseItem', {
-      uid,
-      item,
-      quantity,
-
-      cost,
-      score: newScore,
-      owned: newOwned,
-    });
-    return { score: newScore, owned: newOwned };
-  } catch (err) {
-    await logError('server', err, { function: 'purchaseItem', uid, data });
-    throw err;
-  }
-});
-
-export const updateUserScore = functions.https.onCall(async (data, ctx) => {
-  const uid = ctx.auth?.uid;
-  if (!uid) {
-    throw new functions.https.HttpsError('unauthenticated');
-  }
-  try {
-    if (!(await isAdmin(uid))) {
-      throw new functions.https.HttpsError('permission-denied');
+export const updateUserScore = functions.https.onCall(
+  withAuth(async (uid, data) => {
+    try {
+      if (!(await isAdmin(uid))) {
+        throw new functions.https.HttpsError('permission-denied');
+      }
+      const { username, score } = validateAdminUpdate(data);
+      const db = admin.database();
+      const snap = await db
+        .ref('leaderboard_v3')
+        .orderByChild('username')
+        .equalTo(username)
+        .once('value');
+      if (!snap.exists()) {
+        throw new functions.https.HttpsError('not-found', 'User not found');
+      }
+      const updates = [];
+      snap.forEach((child) => {
+        updates.push(child.ref.update({ score }));
+      });
+      await Promise.all(updates);
+      await logAction('admin', {
+        action: 'updateUserScore',
+        admin: uid,
+        username,
+        score,
+      });
+      return { success: true };
+    } catch (err) {
+      await logError('server', err, { function: 'updateUserScore', uid, data });
+      throw err;
     }
-    const { username, score } = validateAdminUpdate(data);
-    const db = admin.database();
-    const snap = await db
-      .ref('leaderboard_v3')
-      .orderByChild('username')
-      .equalTo(username)
-      .once('value');
-    if (!snap.exists()) {
-      throw new functions.https.HttpsError('not-found', 'User not found');
-    }
-    const updates = [];
-    snap.forEach((child) => {
-      updates.push(child.ref.update({ score }));
-    });
-    await Promise.all(updates);
-    await logAction('admin', {
-      action: 'updateUserScore',
-      admin: uid,
-      username,
-      score,
-    });
-    return { success: true };
-  } catch (err) {
-    await logError('server', err, { function: 'updateUserScore', uid, data });
-    throw err;
-  }
-});
+  }),
+);
 
-export const deleteUser = functions.https.onCall(async (data, ctx) => {
-  const uid = ctx.auth?.uid;
-  if (!uid) {
-    throw new functions.https.HttpsError('unauthenticated');
-  }
-  try {
-    if (!(await isAdmin(uid))) {
-      throw new functions.https.HttpsError('permission-denied');
+export const deleteUser = functions.https.onCall(
+  withAuth(async (uid, data) => {
+    try {
+      if (!(await isAdmin(uid))) {
+        throw new functions.https.HttpsError('permission-denied');
+      }
+      const { username } = validateAdminDelete(data);
+      const db = admin.database();
+      const snap = await db
+        .ref('leaderboard_v3')
+        .orderByChild('username')
+        .equalTo(username)
+        .once('value');
+      if (!snap.exists()) {
+        throw new functions.https.HttpsError('not-found', 'User not found');
+      }
+      const removals = [];
+      snap.forEach((child) => removals.push(child.ref.remove()));
+      await Promise.all(removals);
+      await logAction('admin', { action: 'deleteUser', admin: uid, username });
+      return { success: true };
+    } catch (err) {
+      await logError('server', err, { function: 'deleteUser', uid, data });
+      throw err;
     }
-    const { username } = validateAdminDelete(data);
-    const db = admin.database();
-    const snap = await db
-      .ref('leaderboard_v3')
-      .orderByChild('username')
-      .equalTo(username)
-      .once('value');
-    if (!snap.exists()) {
-      throw new functions.https.HttpsError('not-found', 'User not found');
-    }
-    const removals = [];
-    snap.forEach((child) => removals.push(child.ref.remove()));
-    await Promise.all(removals);
-    await logAction('admin', { action: 'deleteUser', admin: uid, username });
-    return { success: true };
-  } catch (err) {
-    await logError('server', err, { function: 'deleteUser', uid, data });
-    throw err;
-  }
-});
+  }),
+);


### PR DESCRIPTION
## Summary
- introduce withAuth wrapper to extract `uid` and throw `unauthenticated`
- refactor callable functions to use withAuth and remove duplicated auth checks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68992f26ccf88323ada890895cadc5f9