### PR TITLE
refactor: centralize database paths

### DIFF
--- a/functions/logging.js
+++ b/functions/logging.js
@@ -1,9 +1,10 @@
 import admin from 'firebase-admin';
 import * as functions from 'firebase-functions';
+import { LOGS_PATH } from './paths.js';
 
 export function logError(collection, error, payload = {}) {
   try {
-    const ref = admin.database().ref(`logs/${collection}`).push();
+    const ref = admin.database().ref(`${LOGS_PATH}/${collection}`).push();
     return ref.set({
       timestamp: Date.now(),
       message: error.message,
@@ -18,7 +19,7 @@ export function logError(collection, error, payload = {}) {
 
 export async function logAction(collection, payload = {}) {
   try {
-    const ref = admin.database().ref(`logs/${collection}`).push();
+    const ref = admin.database().ref(`${LOGS_PATH}/${collection}`).push();
     await ref.set({
       timestamp: Date.now(),
       ...payload,

--- a/functions/paths.js
+++ b/functions/paths.js
@@ -1,0 +1,4 @@
+export const ADMINS_PATH = 'admins';
+export const LEADERBOARD_PATH = 'leaderboard_v3';
+export const SHOP_PATH = 'shop_v2';
+export const LOGS_PATH = 'logs';


### PR DESCRIPTION
## Summary
- add `paths.js` with constants for Firebase Realtime Database paths
- refactor cloud functions to use shared path constants

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689932af4e488323a2f5fb8ee4c2ace4