### PR TITLE
refactor: centralize username validation

### DIFF
--- a/functions/validation.js
+++ b/functions/validation.js
@@ -34,18 +34,23 @@ export function validatePurchaseItem(data = {}) {
   return { item, quantity };
 }
 
-export function validateAdminUpdate(data = {}) {
+export function validateUsername(rawUsername) {
   const username =
-    typeof data.username === 'string' ? data.username.trim() : '';
-  const score = Number.isInteger(data.score)
-    ? data.score
-    : Math.floor(Number(data.score));
+    typeof rawUsername === 'string' ? rawUsername.trim() : '';
   if (!username || !/^[A-Za-z0-9_]{3,20}$/.test(username)) {
     throw new functions.https.HttpsError(
       'invalid-argument',
       'Invalid username',
     );
   }
+  return username;
+}
+
+export function validateAdminUpdate(data = {}) {
+  const score = Number.isInteger(data.score)
+    ? data.score
+    : Math.floor(Number(data.score));
+  const username = validateUsername(data.username);
   if (!Number.isFinite(score)) {
     throw new functions.https.HttpsError('invalid-argument', 'Invalid score');
   }
@@ -53,13 +58,6 @@ export function validateAdminUpdate(data = {}) {
 }
 
 export function validateAdminDelete(data = {}) {
-  const username =
-    typeof data.username === 'string' ? data.username.trim() : '';
-  if (!username || !/^[A-Za-z0-9_]{3,20}$/.test(username)) {
-    throw new functions.https.HttpsError(
-      'invalid-argument',
-      'Invalid username',
-    );
-  }
+  const username = validateUsername(data.username);
   return { username };
 }


### PR DESCRIPTION
## Summary
- add reusable `validateUsername` helper
- reuse helper in admin update and delete validators

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689935918ae08323bb37484363598abb