### PR TITLE
test: add coverage for presence, shop, ui effects, validation

### DIFF
--- a/functions/__tests__/validation.test.js
+++ b/functions/__tests__/validation.test.js
@@ -1,0 +1,62 @@
+import { describe, test, expect, jest } from '@jest/globals';
+
+jest.unstable_mockModule('firebase-functions', () => ({
+  https: {
+    HttpsError: class extends Error {
+      constructor(code, message) {
+        super(message);
+        this.code = code;
+      }
+    },
+  },
+}));
+
+const {
+  validateSyncGubs,
+  validatePurchaseItem,
+  validateUsername,
+  validateAdminUpdate,
+  validateAdminDelete,
+} = await import('../validation.js');
+
+describe('validation utilities', () => {
+  test('validateSyncGubs clamps delta and parses offline flag', () => {
+    expect(validateSyncGubs({ delta: 2.5, offline: 1 })).toEqual({
+      delta: 2,
+      requestOffline: true,
+    });
+    expect(validateSyncGubs({ delta: 1e7 })).toEqual({
+      delta: 1e6,
+      requestOffline: false,
+    });
+  });
+
+  test('validateSyncGubs rejects non-finite delta', () => {
+    expect(() => validateSyncGubs({ delta: Infinity })).toThrow('Invalid delta');
+  });
+
+  test('validatePurchaseItem validates item and quantity', () => {
+    expect(validatePurchaseItem({ item: 'passiveMaker', quantity: 2 })).toEqual({
+      item: 'passiveMaker',
+      quantity: 2,
+    });
+    expect(() =>
+      validatePurchaseItem({ item: 'nope', quantity: 1 }),
+    ).toThrow('Unknown item');
+  });
+
+  test('validateUsername and admin helpers', () => {
+    expect(validateUsername('Good_User')).toBe('Good_User');
+    expect(() => validateUsername('bad user')).toThrow('Invalid username');
+    expect(
+      validateAdminUpdate({ username: 'AdminUser', score: '5' }),
+    ).toEqual({ username: 'AdminUser', score: 5 });
+    expect(() =>
+      validateAdminUpdate({ username: 'x', score: 1 }),
+    ).toThrow('Invalid username');
+    expect(validateAdminDelete({ username: 'DelUser' })).toEqual({
+      username: 'DelUser',
+    });
+  });
+});
+

--- a/src/__tests__/presence.test.js
+++ b/src/__tests__/presence.test.js
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment jsdom
+ */
+import { describe, test, expect } from '@jest/globals';
+import { initPresenceAndLeaderboard } from '../presence.js';
+
+class FakeRef {
+  constructor() {
+    this.handlers = {};
+  }
+  on(event, cb) {
+    this.handlers[event] = cb;
+  }
+  set() {}
+  onDisconnect() {
+    return { remove: () => {} };
+  }
+  once() {
+    return Promise.resolve({ val: () => null, forEach: () => {} });
+  }
+  trigger(event, snap) {
+    this.handlers[event]?.(snap);
+  }
+}
+
+describe('presence list rendering', () => {
+  test('updates online user list on child events', () => {
+    document.body.innerHTML = '<div id="online-users"></div>';
+    const refs = {};
+    const db = {
+      ref: (path) => {
+        refs[path] ??= new FakeRef();
+        return refs[path];
+      },
+    };
+    const allUsers = new Set();
+    initPresenceAndLeaderboard({
+      db,
+      uid: 'u0',
+      username: 'self',
+      sanitizeUsername: (u) => u,
+      allUsers,
+      CLIENT_VERSION: '1',
+    });
+    const presenceRef = refs['presence'];
+    presenceRef.trigger('child_added', {
+      key: 'a',
+      val: () => 'Alice',
+    });
+    presenceRef.trigger('child_added', {
+      key: 'b',
+      val: () => 'Bob',
+    });
+    expect(document.getElementById('online-users').textContent).toBe(
+      'Online (2): Alice, Bob',
+    );
+    expect(allUsers.has('Alice')).toBe(true);
+    presenceRef.trigger('child_removed', { key: 'a' });
+    expect(document.getElementById('online-users').textContent).toBe(
+      'Online (1): Bob',
+    );
+  });
+
+  test('limits displayed users and shows more count', () => {
+    document.body.innerHTML = '<div id="online-users"></div>';
+    const refs = {};
+    const db = {
+      ref: (path) => {
+        refs[path] ??= new FakeRef();
+        return refs[path];
+      },
+    };
+    initPresenceAndLeaderboard({
+      db,
+      uid: 'u0',
+      username: 'self',
+      sanitizeUsername: (u) => u,
+      allUsers: new Set(),
+      CLIENT_VERSION: '1',
+    });
+    const presenceRef = refs['presence'];
+    for (let i = 0; i < 22; i++) {
+      presenceRef.trigger('child_added', {
+        key: 'u' + i,
+        val: () => 'User' + i,
+      });
+    }
+    const text = document.getElementById('online-users').textContent;
+    expect(text.startsWith('Online (22):')).toBe(true);
+    expect(text.includes('(+2 more)')).toBe(true);
+  });
+});
+

--- a/src/__tests__/shop.test.js
+++ b/src/__tests__/shop.test.js
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment jsdom
+ */
+import { describe, test, expect, jest } from '@jest/globals';
+import { initShop } from '../shop.js';
+
+function setupDOM() {
+  document.body.innerHTML = `
+    <button id="shopBtn"></button>
+    <div id="shopPanel"></div>
+    <div id="shopItemsContainer"></div>
+    <button id="adminBtn" style="display:none"></button>
+    <div id="adminPanel"></div>
+    <input id="adminUsername" />
+    <input id="adminScore" />
+    <button id="adminUpdate"></button>
+    <button id="adminDelete"></button>
+  `;
+}
+
+describe('shop purchasing flow', () => {
+  test('buy button purchases item and updates state', async () => {
+    setupDOM();
+    const uid = 'user123';
+    const refs = {};
+    const db = {
+      ref: (path) => {
+        const ref =
+          refs[path] ||
+          (refs[path] = {
+            on: jest.fn(),
+            once: jest
+              .fn()
+              .mockResolvedValue(
+                path === `shop_v2/${uid}`
+                  ? { val: () => ({}) }
+                  : { val: () => null, exists: () => false },
+              ),
+            set: jest.fn(),
+            onDisconnect: () => ({ remove: jest.fn() }),
+            push: jest.fn(() => ({ set: jest.fn() })),
+            orderByChild: jest.fn().mockReturnThis(),
+            equalTo: jest.fn().mockReturnThis(),
+            update: jest.fn(),
+          });
+        return ref;
+      },
+    };
+    const purchaseItemFn = jest.fn(async () => ({
+      data: { owned: 1, score: 100 },
+    }));
+    const syncGubsFromServer = jest.fn();
+    const renderCounter = jest.fn();
+    const queueScoreUpdate = jest.fn();
+    const passiveWorker = { postMessage: jest.fn() };
+    const gameState = {
+      globalCount: 200,
+      displayedCount: 200,
+      unsyncedDelta: 0,
+      passiveRatePerSec: 0,
+    };
+    initShop({
+      db,
+      uid,
+      purchaseItemFn,
+      updateUserScoreFn: jest.fn(),
+      deleteUserFn: jest.fn(),
+      syncGubsFromServer,
+      gameState,
+      renderCounter,
+      queueScoreUpdate,
+      abbreviateNumber: (n) => String(n),
+      passiveWorker,
+      logError: jest.fn(),
+      sanitizeUsername: (u) => u,
+    });
+    const buyBtn = document.getElementById('buy-passiveMaker');
+    buyBtn.click();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(purchaseItemFn).toHaveBeenCalledWith({
+      item: 'passiveMaker',
+      quantity: 1,
+    });
+    expect(document.getElementById('owned-passiveMaker').textContent).toBe('1');
+    expect(gameState.globalCount).toBe(100);
+    expect(document.getElementById('cost-passiveMaker').textContent).toBe('114');
+    expect(passiveWorker.postMessage).toHaveBeenCalledWith({
+      type: 'rate',
+      value: 1,
+    });
+    expect(renderCounter).toHaveBeenCalled();
+    expect(queueScoreUpdate).toHaveBeenCalled();
+  });
+});
+

--- a/src/__tests__/uiEffects.test.js
+++ b/src/__tests__/uiEffects.test.js
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment jsdom
+ */
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import { initUIEffects } from '../uiEffects.js';
+
+describe('uiEffects settings persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.innerHTML = `
+      <button id="spdDec"></button>
+      <button id="spdInc"></button>
+      <button id="imgDec"></button>
+      <button id="imgInc"></button>
+      <span id="spdVal"></span>
+      <span id="imgVal"></span>
+      <button id="moveToggle"></button>
+      <button id="qualityBtn"></button>
+      <button id="comicBtn"></button>
+      <button id="lowPerfBtn"></button>
+      <div id="perfMenu"></div>
+      <button id="chaosBtn"></button>
+      <button id="twitchBtn"></button>
+      <div id="twitchPlayer"></div>
+    `;
+    const Embed = function () {
+      return { addEventListener: () => {}, getPlayer: () => ({ setMuted: () => {} }) };
+    };
+    Embed.VIDEO_READY = 'ready';
+    global.Twitch = { Embed };
+  });
+
+  test('adjusting speed and image count saves to localStorage', () => {
+    const audio = {
+      state: { flashing: false, musicPlaying: false },
+      chaosAudio: { play: jest.fn(), pause: jest.fn() },
+      audioCtx: { state: 'suspended', resume: jest.fn() },
+    };
+    const imageState = {};
+    initUIEffects({ numFloaters: 0, audio, imageState });
+    document.getElementById('spdInc').click();
+    expect(localStorage.getItem('gubSpeed')).toBe('3');
+    expect(document.getElementById('spdVal').textContent).toBe('3');
+    document.getElementById('imgInc').click();
+    expect(localStorage.getItem('gubImages')).toBe('2');
+    expect(document.getElementById('imgVal').textContent).toBe('2');
+  });
+});
+


### PR DESCRIPTION
## Summary
- test presence list renders online users and handles limits
- test shop purchase flow updates owned count and passive rate
- test UI floater settings persist to localStorage
- test server-side validation utilities for clamping and username rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68993a2d2c3c8323ba3e8ad6b98969ce