### PR TITLE
Handle legacy numeric scores when syncing and purchasing

### DIFF
--- a/functions/__tests__/purchase-item.test.js
+++ b/functions/__tests__/purchase-item.test.js
@@ -37,6 +37,22 @@ describe('purchaseItem', () => {
     expect(rootState.leaderboard_v3[uid].score).toBe(35);
   });
 
+  test('handles scores stored as raw numbers', async () => {
+    const uid = 'userNum';
+    setVal('', {
+      leaderboard_v3: { [uid]: 200 },
+      shop_v2: {},
+    });
+
+    const result = await purchaseItem(
+      { item: 'passiveMaker', quantity: 1 },
+      { auth: { uid } },
+    );
+    expect(result).toEqual({ score: 100, owned: 1 });
+    expect(rootState.shop_v2[uid].passiveMaker).toBe(1);
+    expect(rootState.leaderboard_v3[uid].score).toBe(100);
+  });
+
   test('rejects unknown shop items', async () => {
     const uid = 'user2';
     setVal('', { leaderboard_v3: { [uid]: { score: 1000 } }, shop_v2: {} });

--- a/functions/__tests__/sync-gubs.test.js
+++ b/functions/__tests__/sync-gubs.test.js
@@ -56,4 +56,12 @@ describe('syncGubs', () => {
     expect(res).toEqual({ score: 1e6, offlineEarned: 0 });
     expect(rootState.leaderboard_v3[uid].score).toBe(1e6);
   });
+
+  test('handles legacy numeric leaderboard entries', async () => {
+    const uid = 'user4';
+    setVal('', { leaderboard_v3: { [uid]: 50 }, shop_v2: {} });
+    const res = await syncGubs({ delta: 10 }, { auth: { uid } });
+    expect(res).toEqual({ score: 60, offlineEarned: 0 });
+    expect(rootState.leaderboard_v3[uid].score).toBe(60);
+  });
 });


### PR DESCRIPTION
## Summary
- allow syncGubs to convert raw numeric leaderboard entries into structured objects
- ensure purchaseItem reads and updates legacy numeric scores
- add tests covering numeric leaderboard entries

## Testing
- `npm test`
- `npm run lint` *(fails: prettier/prettier in functions/__tests__/validation.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689944f4f59083238044282f8458b295