### PR TITLE
Handle purchase attempts when sync fails

### DIFF
--- a/src/__tests__/shop.test.js
+++ b/src/__tests__/shop.test.js
@@ -92,5 +92,67 @@ describe('shop purchasing flow', () => {
     expect(renderCounter).toHaveBeenCalled();
     expect(queueScoreUpdate).toHaveBeenCalled();
   });
+
+  test('purchase is aborted if sync fails', async () => {
+    setupDOM();
+    const uid = 'user123';
+    const refs = {};
+    const db = {
+      ref: (path) => {
+        const ref =
+          refs[path] ||
+          (refs[path] = {
+            on: jest.fn(),
+            once: jest
+              .fn()
+              .mockResolvedValue(
+                path === `shop_v2/${uid}`
+                  ? { val: () => ({}) }
+                  : { val: () => null, exists: () => false },
+              ),
+            set: jest.fn(),
+            onDisconnect: () => ({ remove: jest.fn() }),
+            push: jest.fn(() => ({ set: jest.fn() })),
+            orderByChild: jest.fn().mockReturnThis(),
+            equalTo: jest.fn().mockReturnThis(),
+            update: jest.fn(),
+          });
+        return ref;
+      },
+    };
+    const purchaseItemFn = jest.fn();
+    const syncGubsFromServer = jest
+      .fn()
+      .mockRejectedValue(new Error('network'));
+    const logError = jest.fn();
+    const passiveWorker = { postMessage: jest.fn() };
+    const gameState = {
+      globalCount: 200,
+      displayedCount: 200,
+      unsyncedDelta: 0,
+      passiveRatePerSec: 0,
+    };
+    initShop({
+      db,
+      uid,
+      purchaseItemFn,
+      updateUserScoreFn: jest.fn(),
+      deleteUserFn: jest.fn(),
+      syncGubsFromServer,
+      gameState,
+      renderCounter: jest.fn(),
+      queueScoreUpdate: jest.fn(),
+      abbreviateNumber: (n) => String(n),
+      passiveWorker,
+      logError,
+      sanitizeUsername: (u) => u,
+    });
+    const buyBtn = document.getElementById('buy-passiveMaker');
+    buyBtn.click();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(purchaseItemFn).not.toHaveBeenCalled();
+    expect(logError).toHaveBeenCalled();
+  });
 });
 

--- a/src/gameLoop.js
+++ b/src/gameLoop.js
@@ -83,6 +83,7 @@ export function initGameLoop({
           stack: err.stack,
           context: 'syncGubsFromServer',
         });
+        throw err;
       } finally {
         syncingPromise = null;
       }
@@ -98,12 +99,12 @@ export function initGameLoop({
   setInterval(() => {
     if (scoreDirty) {
       scoreDirty = false;
-      syncGubsFromServer();
+      syncGubsFromServer().catch(() => {});
     }
   }, 1000);
 
   // Regularly pull server-side gub totals even if no local actions
-  setInterval(syncGubsFromServer, 10000);
+  setInterval(() => syncGubsFromServer().catch(() => {}), 10000);
 
   function abbreviateNumber(num) {
     if (num < 1000) return Math.floor(num).toString();
@@ -143,7 +144,7 @@ export function initGameLoop({
     }
     displayedCount = globalCount;
     renderCounter();
-    syncGubsFromServer(true);
+    syncGubsFromServer(true).catch(() => {});
 
     // Keep local score in sync with external/manual updates
     userRef.on('value', (s) => {
@@ -236,7 +237,7 @@ export function initGameLoop({
   document.addEventListener('visibilitychange', () => {
     if (!document.hidden) {
       passiveWorker.postMessage({ type: 'reset' });
-      syncGubsFromServer(true);
+      syncGubsFromServer(true).catch(() => {});
     }
   });
   // main gub handler

--- a/src/shop.js
+++ b/src/shop.js
@@ -144,7 +144,17 @@ export function initShop({
     }
 
     async function attemptPurchase(quantity) {
-      await syncGubsFromServer();
+      try {
+        await syncGubsFromServer();
+      } catch (err) {
+        console.error('syncGubsFromServer failed', err);
+        logError(db, {
+          message: err.message,
+          stack: err.stack,
+          context: 'attemptPurchase.sync',
+        });
+        return;
+      }
       const cost = calcTotalCost(
         item.baseCost,
         owned[item.id],


### PR DESCRIPTION
## Summary
- abort shop purchases if syncing gubs to server fails
- propagate sync errors and catch them in game loop
- test purchase flow when sync errors occur

## Testing
- `npm test`
- `npm run lint` *(fails: prettier/prettier errors in functions/validation.js)*

------
https://chatgpt.com/codex/tasks/task_e_689947eaaddc8323ab087653d9d12d85