### PR TITLE
Log transaction score and pause sync during purchases

### DIFF
--- a/functions/__tests__/validation.test.js
+++ b/functions/__tests__/validation.test.js
@@ -32,31 +32,35 @@ describe('validation utilities', () => {
   });
 
   test('validateSyncGubs rejects non-finite delta', () => {
-    expect(() => validateSyncGubs({ delta: Infinity })).toThrow('Invalid delta');
+    expect(() => validateSyncGubs({ delta: Infinity })).toThrow(
+      'Invalid delta',
+    );
   });
 
   test('validatePurchaseItem validates item and quantity', () => {
-    expect(validatePurchaseItem({ item: 'passiveMaker', quantity: 2 })).toEqual({
-      item: 'passiveMaker',
-      quantity: 2,
-    });
-    expect(() =>
-      validatePurchaseItem({ item: 'nope', quantity: 1 }),
-    ).toThrow('Unknown item');
+    expect(validatePurchaseItem({ item: 'passiveMaker', quantity: 2 })).toEqual(
+      {
+        item: 'passiveMaker',
+        quantity: 2,
+      },
+    );
+    expect(() => validatePurchaseItem({ item: 'nope', quantity: 1 })).toThrow(
+      'Unknown item',
+    );
   });
 
   test('validateUsername and admin helpers', () => {
     expect(validateUsername('Good_User')).toBe('Good_User');
     expect(() => validateUsername('bad user')).toThrow('Invalid username');
-    expect(
-      validateAdminUpdate({ username: 'AdminUser', score: '5' }),
-    ).toEqual({ username: 'AdminUser', score: 5 });
-    expect(() =>
-      validateAdminUpdate({ username: 'x', score: 1 }),
-    ).toThrow('Invalid username');
+    expect(validateAdminUpdate({ username: 'AdminUser', score: '5' })).toEqual({
+      username: 'AdminUser',
+      score: 5,
+    });
+    expect(() => validateAdminUpdate({ username: 'x', score: 1 })).toThrow(
+      'Invalid username',
+    );
     expect(validateAdminDelete({ username: 'DelUser' })).toEqual({
       username: 'DelUser',
     });
   });
 });
-

--- a/functions/index.js
+++ b/functions/index.js
@@ -139,6 +139,12 @@ export const purchaseItem = functions.https.onCall(
         }
         const currentScore = Number(user.score) || 0;
         availableScore = currentScore;
+        functions.logger.info('purchaseItem.transaction', {
+          uid,
+          item,
+          currentScore,
+          cost,
+        });
         if (currentScore < cost) return; // abort
         return {
           ...user,

--- a/functions/validation.js
+++ b/functions/validation.js
@@ -35,8 +35,7 @@ export function validatePurchaseItem(data = {}) {
 }
 
 export function validateUsername(rawUsername) {
-  const username =
-    typeof rawUsername === 'string' ? rawUsername.trim() : '';
+  const username = typeof rawUsername === 'string' ? rawUsername.trim() : '';
   if (!username || !/^[A-Za-z0-9_]{3,20}$/.test(username)) {
     throw new functions.https.HttpsError(
       'invalid-argument',

--- a/src/gameLoop.js
+++ b/src/gameLoop.js
@@ -44,6 +44,7 @@ export function initGameLoop({
   let offlineShown = false;
   let gubRateMultiplier = 1;
   let scoreDirty = false;
+  let syncPaused = false;
 
   let syncingPromise = null;
   async function syncGubsFromServer(requestOffline = false) {
@@ -97,14 +98,18 @@ export function initGameLoop({
   }
 
   setInterval(() => {
-    if (scoreDirty) {
+    if (scoreDirty && !syncPaused) {
       scoreDirty = false;
       syncGubsFromServer().catch(() => {});
     }
   }, 1000);
 
   // Regularly pull server-side gub totals even if no local actions
-  setInterval(() => syncGubsFromServer().catch(() => {}), 10000);
+  setInterval(() => {
+    if (!syncPaused) {
+      syncGubsFromServer().catch(() => {});
+    }
+  }, 10000);
 
   function abbreviateNumber(num) {
     if (num < 1000) return Math.floor(num).toString();
@@ -313,6 +318,12 @@ export function initGameLoop({
     },
     set passiveRatePerSec(v) {
       passiveRatePerSec = v;
+    },
+    get syncPaused() {
+      return syncPaused;
+    },
+    set syncPaused(v) {
+      syncPaused = v;
     },
   };
   initShop({


### PR DESCRIPTION
## Summary
- Log the score observed inside `purchaseItem`'s transaction to aid debugging.
- Add `syncPaused` flag to pause background `syncGubs` polling during purchases.
- Format validation files to satisfy linting.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68995316718483238d45a1e3fa28b9bd