### PR TITLE
Add game loop teardown and cleanup

### DIFF
--- a/src/__tests__/gameLoop.test.js
+++ b/src/__tests__/gameLoop.test.js
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest, test, expect } from '@jest/globals';
+
+test('destroy clears timers and terminates worker', async () => {
+  jest.useFakeTimers();
+  jest.resetModules();
+
+  await jest.unstable_mockModule('../chat.js', () => ({ initChat: jest.fn() }));
+  await jest.unstable_mockModule('../goldenGub.js', () => ({
+    initGoldenGubs: jest.fn(() => ({ scheduleNextGolden: jest.fn() })),
+  }));
+  await jest.unstable_mockModule('../presence.js', () => ({
+    initPresenceAndLeaderboard: jest.fn(),
+  }));
+  await jest.unstable_mockModule('../shop.js', () => ({ initShop: jest.fn() }));
+
+  const { initGameLoop } = await import('../gameLoop.js');
+
+  document.body.innerHTML = `
+    <div id="offlineModal"></div>
+    <div id="offlineMessage"></div>
+    <button id="offlineClose"></button>
+    <div id="gubTotal"></div>
+    <div id="main-gub"></div>
+    <div id="clickMe"></div>
+    <div id="leaderboard"></div>
+  `;
+
+  const terminate = jest.fn();
+  global.Worker = jest.fn(() => ({ postMessage: jest.fn(), terminate }));
+
+  const createRef = () => {
+    const ref = {
+      once: jest.fn(() => Promise.resolve({ exists: () => false, val: () => 0 })),
+      on: jest.fn(),
+      off: jest.fn(),
+      orderByChild: jest.fn(() => ref),
+      limitToLast: jest.fn(() => ref),
+      parent: { remove: jest.fn() },
+    };
+    return ref;
+  };
+  const db = { ref: jest.fn(() => createRef()) };
+  const functions = {
+    httpsCallable: jest.fn(() => jest.fn(() => Promise.resolve({ data: { score: 0 } }))),
+  };
+  const auth = { currentUser: { uid: 'uid' } };
+
+  const destroy = initGameLoop({
+    db,
+    functions,
+    auth,
+    username: 'user',
+    sanitizeUsername: (x) => x,
+    playMentionSound: jest.fn(),
+    CLIENT_VERSION: 'test',
+    imageState: { images: [] },
+  });
+
+  await Promise.resolve();
+  expect(jest.getTimerCount()).toBeGreaterThan(0);
+
+  destroy();
+
+  expect(terminate).toHaveBeenCalled();
+  expect(jest.getTimerCount()).toBe(0);
+
+  jest.useRealTimers();
+  delete global.Worker;
+});

--- a/src/main.js
+++ b/src/main.js
@@ -44,7 +44,7 @@ window.addEventListener('DOMContentLoaded', () => {
       .signInAnonymously()
       .then(() => {
         initErrorLogging(db);
-        initGameLoop({
+        const destroyGameLoop = initGameLoop({
           db,
           functions,
           auth,
@@ -55,6 +55,14 @@ window.addEventListener('DOMContentLoaded', () => {
           imageState,
         });
         initFeedback({ db, username });
+
+        window.addEventListener('beforeunload', destroyGameLoop);
+        if (import.meta.hot) {
+          import.meta.hot.dispose(() => {
+            window.removeEventListener('beforeunload', destroyGameLoop);
+            destroyGameLoop();
+          });
+        }
       })
       .catch((err) => console.error('Auth Error', err));
 


### PR DESCRIPTION
## Summary
- return a `destroy` function from `initGameLoop` to clear timers, remove listeners, and terminate the worker
- invoke game loop teardown on page unload and during hot module replacement
- test that timers are removed when the game loop is destroyed

## Testing
- `npm test` *(fails: lockRef.remove is not a function; shop purchasing flow tests failing)*
- `npm run lint` *(fails: functions/index.js prettier/no-unused-vars errors)*

------
https://chatgpt.com/codex/tasks/task_e_689d63f2ecbc8323b421eb718f8741c2