### PR TITLE
Remove WIP banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,6 @@
     ></script>
   </head>
   <body>
-    <div id="wipBanner">Site is WIP, things will be broken often</div>
     <div id="btnRow">
       <button id="lowPerfBtn">Settings Menu</button>
       <button id="chaosBtn">

--- a/styles/base.css
+++ b/styles/base.css
@@ -6,19 +6,6 @@ body {
   height: 100vh;
   width: 100vw;
 }
-#wipBanner {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  text-align: center;
-  color: red;
-  background: #000;
-  z-index: 10002;
-  font-family: sans-serif;
-  font-weight: bold;
-  padding: 8px 0;
-}
 #gub-wrapper {
   position: absolute;
   top: 50%;
@@ -491,5 +478,5 @@ body {
 
 body.comic-sans,
 body.comic-sans * {
-  font-family: "Comic Sans MS", "Comic Sans", cursive !important;
+  font-family: 'Comic Sans MS', 'Comic Sans', cursive !important;
 }


### PR DESCRIPTION
## Summary
- Remove temporary WIP notice from homepage
- Drop unused wip banner styles

## Testing
- `npm run lint` *(fails: functions/index.js lint errors)*
- `npm test` *(fails: lockRef.remove is not a function in functions tests)*

------
https://chatgpt.com/codex/tasks/task_e_689d667e89ec83238485fff7d04bf95f