### PR TITLE
Check for duplicate usernames on join

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -36,8 +36,9 @@ window.addEventListener('DOMContentLoaded', () => {
 `;
   document.head.appendChild(specialStyle);
 
-  initUsername((username) => {
-    const { auth, db, functions } = initFirebase();
+  const { auth, db, functions } = initFirebase();
+
+  initUsername(db, (username) => {
     const imageState = { images: [] };
 
     auth

--- a/src/username.js
+++ b/src/username.js
@@ -5,7 +5,7 @@ export function sanitizeUsername(name) {
     .slice(0, 20);
 }
 
-export function initUsername(onReady) {
+export function initUsername(db, onReady) {
   let username = sanitizeUsername(localStorage.getItem('gubUser'));
 
   function showUsernamePrompt() {
@@ -13,9 +13,23 @@ export function initUsername(onReady) {
     const input = document.getElementById('usernameInput');
     const submit = document.getElementById('usernameSubmit');
     overlay.style.display = 'flex';
-    function accept() {
+    async function accept() {
       const u = sanitizeUsername(input.value);
       if (u.length >= 3) {
+        try {
+          const snap = await db
+            .ref('leaderboard_v3')
+            .orderByChild('username')
+            .equalTo(u)
+            .once('value');
+          if (snap.exists()) {
+            alert('Username already taken');
+            return;
+          }
+        } catch (err) {
+          console.error('Username check failed', err);
+          return;
+        }
         username = u;
         localStorage.setItem('gubUser', username);
         overlay.style.display = 'none';


### PR DESCRIPTION
## Summary
- ensure username prompt rejects names already on the leaderboard
- initialize Firebase before prompting for username
- extend function test mocks for remove/update

## Testing
- `npm test` *(fails: shop purchasing flow tests)*

------
https://chatgpt.com/codex/tasks/task_e_689d67cd6f908323838172b73df9b8d5