### PR TITLE
Add mobile shop toggle button

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
         Chaos Mode <span style="font-size: 10px">(epilepsy warning)</span>
       </button>
       <button id="twitchBtn">Show Stream</button>
+      <button id="shopToggleBtn">Hide Shop</button>
       <button id="adminBtn">Admin</button>
     </div>
 

--- a/src/shop.js
+++ b/src/shop.js
@@ -62,6 +62,14 @@ export function initShop({
   const adminScore = document.getElementById('adminScore');
   const adminUpdate = document.getElementById('adminUpdate');
   const adminDelete = document.getElementById('adminDelete');
+  const shopToggleBtn = document.getElementById('shopToggleBtn');
+  if (shopToggleBtn) {
+    shopToggleBtn.addEventListener('click', () => {
+      const hidden = shopPanel.style.display === 'none';
+      shopPanel.style.display = hidden ? 'block' : 'none';
+      shopToggleBtn.textContent = hidden ? 'Hide Shop' : 'Show Shop';
+    });
+  }
 
   const ADMIN_UIDS = [
     'sGd1ZHR1nvMKKCw9A1O5bwtbFD23',

--- a/styles/base.css
+++ b/styles/base.css
@@ -191,6 +191,9 @@ body {
 .feral-glow {
   filter: drop-shadow(0 0 10px gold) drop-shadow(0 0 20px gold);
 }
+#shopToggleBtn {
+  display: none;
+}
 @media (max-width: 768px) {
   #discordWrapper {
     bottom: 170px !important; /* move it up above the chat */
@@ -198,6 +201,9 @@ body {
   }
   #golden-counter {
     top: 60px !important; /* push it down under the btnRow */
+  }
+  #shopToggleBtn {
+    display: inline-block;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add mobile-only button to toggle shop panel visibility
- Hide toggle button on desktop via CSS
- Wire up shop toggle behavior in shop.js

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d72486280832387f6ef32a17525b6