### PR TITLE
feat: add images to shop items

### DIFF
--- a/functions/shared/shop-config.js
+++ b/functions/shared/shop-config.js
@@ -37,12 +37,14 @@ export default {
       name: 'Gub Space Program',
       baseCost: 625000000,
       rate: 6250000,
+      image: 'small_gub_02_Glurp.png',
     },
     {
       id: 'intergalactic',
       name: 'Intergalactic Gub',
       baseCost: 3125000000,
       rate: 31250000,
+      image: 'small_gub_01_gluburple.png',
     },
   ],
 };

--- a/shared/shop-config.js
+++ b/shared/shop-config.js
@@ -37,12 +37,14 @@ export default {
       name: 'Gub Space Program',
       baseCost: 625000000,
       rate: 6250000,
+      image: 'small_gub_02_Glurp.png',
     },
     {
       id: 'intergalactic',
       name: 'Intergalactic Gub',
       baseCost: 3125000000,
       rate: 31250000,
+      image: 'small_gub_01_gluburple.png',
     },
   ],
 };

--- a/src/shop.js
+++ b/src/shop.js
@@ -121,21 +121,33 @@ export function initShop({
   // Render each shop item
   shopItems.forEach((item) => {
     const div = document.createElement('div');
+    div.className = 'shop-item';
     div.innerHTML = `
-      <strong>${item.name}</strong>${
-        item.caption ? ` <span style="color:red;font-size:0.8em;">${item.caption}</span>` : ''
-      }<br>
-      Cost: <span id="cost-${item.id}"></span> Gubs<br>
-      Rate: ${abbreviateNumber(item.rate)} Gub/s<br>
-      Owned: <span id="owned-${item.id}">0</span><br>
-      <button id="buy-${item.id}">Buy</button>
-      <button id="buy-${item.id}-x10">x10</button>
-      <button id="buy-${item.id}-x100">x100</button>
-      <button id="buy-${item.id}-all">All</button>
-      <div id="error-${item.id}" style="color:red;display:none;font-size:0.8em;"></div>
-      <hr style="border-color:#444">
+      ${
+        item.image
+          ? `<img src="${item.image}" alt="${item.name}" class="shop-item-image">`
+          : ''
+      }
+      <div class="shop-item-details">
+        <strong>${item.name}</strong>${
+          item.caption
+            ? ` <span style="color:red;font-size:0.8em;">${item.caption}</span>`
+            : ''
+        }<br>
+        Cost: <span id="cost-${item.id}"></span> Gubs<br>
+        Rate: ${abbreviateNumber(item.rate)} Gub/s<br>
+        Owned: <span id="owned-${item.id}">0</span><br>
+        <button id="buy-${item.id}">Buy</button>
+        <button id="buy-${item.id}-x10">x10</button>
+        <button id="buy-${item.id}-x100">x100</button>
+        <button id="buy-${item.id}-all">All</button>
+        <div id="error-${item.id}" style="color:red;display:none;font-size:0.8em;"></div>
+      </div>
     `;
     shopContainer.appendChild(div);
+    const hr = document.createElement('hr');
+    hr.style.borderColor = '#444';
+    shopContainer.appendChild(hr);
 
     const buy1 = div.querySelector(`#buy-${item.id}`);
     const buy10 = div.querySelector(`#buy-${item.id}-x10`);

--- a/styles/base.css
+++ b/styles/base.css
@@ -231,6 +231,19 @@ body {
   margin-bottom: 0.5em;
 }
 
+#shopItemsContainer .shop-item {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  text-align: center;
+}
+
+#shopItemsContainer .shop-item img {
+  width: 32px;
+  height: 32px;
+}
+
 #adminPanel {
   position: absolute;
   top: 90px;


### PR DESCRIPTION
## Summary
- display optional images beside shop entries
- add gluburple icon for Intergalactic Gub and glurp icon for Gub Space Program
- center shop items with new styling
- sync shop item images to Cloud Functions shared config

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e23b86b708323a638fa432ab162ec