### PR TITLE
Remove sync delta clamp

### DIFF
--- a/functions/__tests__/sync-gubs.test.js
+++ b/functions/__tests__/sync-gubs.test.js
@@ -46,15 +46,15 @@ describe('syncGubs', () => {
     ).rejects.toHaveProperty('code', 'invalid-argument');
   });
 
-  test('clamps large delta', async () => {
+  test('syncs large delta without clamping', async () => {
     const uid = 'user3';
     setVal('', {
       leaderboard_v3: { [uid]: { score: 0, lastUpdated: 0 } },
       shop_v2: {},
     });
     const res = await syncGubs({ delta: 1e7 }, { auth: { uid } });
-    expect(res).toEqual({ score: 1e6, offlineEarned: 0 });
-    expect(rootState.leaderboard_v3[uid].score).toBe(1e6);
+    expect(res).toEqual({ score: 1e7, offlineEarned: 0 });
+    expect(rootState.leaderboard_v3[uid].score).toBe(1e7);
   });
 
   test('handles legacy numeric leaderboard entries', async () => {

--- a/functions/__tests__/validation.test.js
+++ b/functions/__tests__/validation.test.js
@@ -20,13 +20,14 @@ const {
 } = await import('../validation.js');
 
 describe('validation utilities', () => {
-  test('validateSyncGubs clamps delta and parses offline flag', () => {
+  test('validateSyncGubs floors delta and parses offline flag', () => {
     expect(validateSyncGubs({ delta: 2.5, offline: 1 })).toEqual({
       delta: 2,
       requestOffline: true,
     });
+    // Large deltas should be accepted as-is to allow high rate syncing
     expect(validateSyncGubs({ delta: 1e7 })).toEqual({
-      delta: 1e6,
+      delta: 1e7,
       requestOffline: false,
     });
   });

--- a/functions/validation.js
+++ b/functions/validation.js
@@ -6,7 +6,12 @@ export function validateSyncGubs(data = {}) {
   if (!Number.isFinite(rawDelta)) {
     throw new functions.https.HttpsError('invalid-argument', 'Invalid delta');
   }
-  const delta = Math.max(-1e6, Math.min(1e6, Math.floor(rawDelta)));
+  // Previously we clamped the delta to +/-1e6 to prevent excessive writes.
+  // High rate players now quickly exceed this limit causing their scores to
+  // fall behind as only a portion of their local delta could be synced each
+  // tick.  The database can handle larger updates, so we simply floor the
+  // value without clamping so the full amount is applied in a single call.
+  const delta = Math.floor(rawDelta);
   const requestOffline = Boolean(data.offline);
   return { delta, requestOffline };
 }


### PR DESCRIPTION
## Summary
- allow large sync deltas by removing +/-1e6 clamp
- adjust validation utilities and tests for unrestricted delta

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e2e7eb3d883239970ca16216ef235