### PR TITLE
Enlarge shop gubs and align item text

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -234,14 +234,15 @@ body {
 #shopItemsContainer .shop-item {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 8px;
-  text-align: center;
+  text-align: left;
 }
 
 #shopItemsContainer .shop-item img {
-  width: 32px;
-  height: 32px;
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
 }
 
 #adminPanel {


### PR DESCRIPTION
## Summary
- widen shop gub image size for better visibility
- left-align shop item details so text lines up uniformly

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e320b4ce0832388c2ab5f372e0cbf