### PR TITLE
Ensure settings menu overlays UI and add purchase sound

### DIFF
--- a/src/audio.js
+++ b/src/audio.js
@@ -71,5 +71,21 @@ export function initAudio() {
     osc.stop(audioCtx.currentTime + 0.2);
   }
 
-  return { chaosAudio, audioCtx, playMentionSound, state };
+  function playBuySound() {
+    const osc = audioCtx.createOscillator();
+    const gain = audioCtx.createGain();
+    osc.type = "square";
+    osc.frequency.value = 440;
+    osc.connect(gain);
+    gain.connect(audioCtx.destination);
+    gain.gain.setValueAtTime(0.3, audioCtx.currentTime);
+    gain.gain.exponentialRampToValueAtTime(
+      0.001,
+      audioCtx.currentTime + 0.1,
+    );
+    osc.start();
+    osc.stop(audioCtx.currentTime + 0.1);
+  }
+
+  return { chaosAudio, audioCtx, playMentionSound, playBuySound, state };
 }

--- a/src/gameLoop.js
+++ b/src/gameLoop.js
@@ -11,6 +11,7 @@ export function initGameLoop({
   username,
   sanitizeUsername,
   playMentionSound,
+  playBuySound = () => {},
   CLIENT_VERSION,
   imageState,
 }) {
@@ -328,6 +329,7 @@ export function initGameLoop({
     passiveWorker,
     logError,
     sanitizeUsername,
+    playBuySound,
   });
 
   return function destroy() {

--- a/src/main.js
+++ b/src/main.js
@@ -13,7 +13,7 @@ window.addEventListener('DOMContentLoaded', () => {
   const NUM_FLOATERS = isMobile ? 5 : 20;
 
   const audio = initAudio();
-  const { playMentionSound } = audio;
+  const { playMentionSound, playBuySound } = audio;
   // ─── SPECIAL GUB STYLE ───
   const specialStyle = document.createElement('style');
   specialStyle.textContent = `
@@ -52,6 +52,7 @@ window.addEventListener('DOMContentLoaded', () => {
           username,
           sanitizeUsername,
           playMentionSound,
+          playBuySound,
           CLIENT_VERSION,
           imageState,
         });

--- a/src/shop.js
+++ b/src/shop.js
@@ -22,6 +22,7 @@ export function initShop({
   passiveWorker,
   logError,
   sanitizeUsername,
+  playBuySound = () => {},
 }) {
   const COST_MULTIPLIER = shopConfig.costMultiplier;
   const shopItems = shopConfig.items;
@@ -168,6 +169,7 @@ export function initShop({
     async function attemptPurchase(quantity) {
       if (purchasing) return;
       purchasing = true;
+      playBuySound();
 
       // disable these buttons while in-flight
       [buy1, buy10, buy100, buyAll].forEach((b) => (b.disabled = true));

--- a/styles/base.css
+++ b/styles/base.css
@@ -57,7 +57,7 @@ body {
   position: absolute;
   top: 50px;
   left: 10px;
-  z-index: 9998;
+  z-index: 10002;
   background: #222;
   color: #fff;
   border: 1px solid #555;


### PR DESCRIPTION
## Summary
- Raise settings menu z-index so it always appears above leaderboard
- Play stacking "buy" sound whenever a shop item is purchased

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e3ad236788323875bdf1b7bc26cb8