### PR TITLE
Soften purchase sound

### DIFF
--- a/src/__tests__/audio.test.js
+++ b/src/__tests__/audio.test.js
@@ -92,6 +92,6 @@ describe('initAudio', () => {
     const audio = initAudio();
     audio.playBuySound();
     expect(lastOscillator.frequency.value).toBe(220);
-    expect(lastGainValue).toBeCloseTo(0.15);
+    expect(lastGainValue).toBeCloseTo(0.1);
   });
 });

--- a/src/audio.js
+++ b/src/audio.js
@@ -79,8 +79,8 @@ export function initAudio() {
     osc.frequency.value = 220;
     osc.connect(gain);
     gain.connect(audioCtx.destination);
-    // Reduce volume so the sound is less jarring
-    gain.gain.setValueAtTime(0.15, audioCtx.currentTime);
+    // Further reduce volume so the purchase sound is softer
+    gain.gain.setValueAtTime(0.1, audioCtx.currentTime);
     gain.gain.exponentialRampToValueAtTime(
       0.001,
       audioCtx.currentTime + 0.1,


### PR DESCRIPTION
## Summary
- Lower purchase sound volume for a softer feedback when buying items
- Adjust tests for updated volume

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e3ee7dcfc83239c62ba62d1e9f2ec