### PR TITLE
Remove All purchase option from shop

### DIFF
--- a/src/__tests__/shop.test.js
+++ b/src/__tests__/shop.test.js
@@ -212,21 +212,22 @@ describe('shop purchasing flow', () => {
     });
     const buy1 = document.getElementById('buy-passiveMaker');
     const buy10 = document.getElementById('buy-passiveMaker-x10');
-    const buyAll = document.getElementById('buy-passiveMaker-all');
+    const buy100 = document.getElementById('buy-passiveMaker-x100');
     jest.advanceTimersByTime(200);
     expect(buy1.disabled).toBe(true);
     expect(buy10.disabled).toBe(true);
-    expect(buyAll.disabled).toBe(true);
+    expect(buy100.disabled).toBe(true);
 
     gameState.globalCount = 150;
     jest.advanceTimersByTime(200);
     expect(buy1.disabled).toBe(false);
     expect(buy10.disabled).toBe(true);
-    expect(buyAll.disabled).toBe(false);
+    expect(buy100.disabled).toBe(true);
 
     gameState.globalCount = 3000;
     jest.advanceTimersByTime(200);
     expect(buy10.disabled).toBe(false);
+    expect(buy100.disabled).toBe(true);
     jest.useRealTimers();
   });
 });

--- a/src/shop.js
+++ b/src/shop.js
@@ -1,7 +1,6 @@
 import {
   shopConfig,
   currentCost as calcCurrentCost,
-  maxAffordable as calcMaxAffordable,
   totalCost as calcTotalCost,
 } from '../shared/index.js';
 
@@ -144,7 +143,6 @@ export function initShop({
         <button id="buy-${item.id}">Buy</button>
         <button id="buy-${item.id}-x10">x10</button>
         <button id="buy-${item.id}-x100">x100</button>
-        <button id="buy-${item.id}-all">All</button>
         <div id="error-${item.id}" style="color:red;display:none;font-size:0.8em;"></div>
       </div>
     `;
@@ -156,7 +154,6 @@ export function initShop({
     const buy1 = div.querySelector(`#buy-${item.id}`);
     const buy10 = div.querySelector(`#buy-${item.id}-x10`);
     const buy100 = div.querySelector(`#buy-${item.id}-x100`);
-    const buyAll = div.querySelector(`#buy-${item.id}-all`);
     const costSpan = div.querySelector(`#cost-${item.id}`);
     const errorEl = div.querySelector(`#error-${item.id}`);
     let errorTimeoutId;
@@ -190,13 +187,6 @@ export function initShop({
         COST_MULTIPLIER,
       );
       buy100.disabled = gubs < cost100;
-      const maxAll = calcMaxAffordable(
-        item.baseCost,
-        ownedCount,
-        gubs,
-        COST_MULTIPLIER,
-      );
-      buyAll.disabled = maxAll <= 0;
     }
     updateFns.push(updateButtons);
 
@@ -206,7 +196,7 @@ export function initShop({
       playBuySound();
 
       // disable these buttons while in-flight
-      [buy1, buy10, buy100, buyAll].forEach((b) => (b.disabled = true));
+      [buy1, buy10, buy100].forEach((b) => (b.disabled = true));
 
       // pause background sync loop so we don't race the server op
       if (typeof pauseSync === 'function') pauseSync();
@@ -260,7 +250,7 @@ export function initShop({
         });
       } finally {
         if (typeof resumeSync === 'function') resumeSync();
-        [buy1, buy10, buy100, buyAll].forEach((b) => (b.disabled = false));
+        [buy1, buy10, buy100].forEach((b) => (b.disabled = false));
         updateButtons();
         purchasing = false;
       }
@@ -269,15 +259,6 @@ export function initShop({
     buy1.addEventListener('click', () => attemptPurchase(1));
     buy10.addEventListener('click', () => attemptPurchase(10));
     buy100.addEventListener('click', () => attemptPurchase(100));
-    buyAll.addEventListener('click', () => {
-      const qty = calcMaxAffordable(
-        item.baseCost,
-        owned[item.id] || 0,
-        gameState.globalCount,
-        COST_MULTIPLIER,
-      );
-      if (qty > 0) attemptPurchase(qty);
-    });
 
     updateCostDisplay();
     updateButtons();


### PR DESCRIPTION
## Summary
- drop "All" purchase button and related logic from shop module
- adjust shop tests to cover buy, x10, and x100 quantities only

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e494d1838832389e405d8d8920e22