### PR TITLE
Use x1 label for single shop purchases

### DIFF
--- a/src/__tests__/shop.test.js
+++ b/src/__tests__/shop.test.js
@@ -75,6 +75,7 @@ describe('shop purchasing flow', () => {
       sanitizeUsername: (u) => u,
     });
     const buyBtn = document.getElementById('buy-passiveMaker');
+    expect(buyBtn.textContent).toBe('x1');
     buyBtn.click();
     await Promise.resolve();
     await Promise.resolve();

--- a/src/shop.js
+++ b/src/shop.js
@@ -140,7 +140,7 @@ export function initShop({
         Cost: <span id="cost-${item.id}"></span> Gubs<br>
         Rate: ${abbreviateNumber(item.rate)} Gub/s<br>
         Owned: <span id="owned-${item.id}">0</span><br>
-        <button id="buy-${item.id}">Buy</button>
+        <button id="buy-${item.id}">x1</button>
         <button id="buy-${item.id}-x10">x10</button>
         <button id="buy-${item.id}-x100">x100</button>
       </div>


### PR DESCRIPTION
## Summary
- Replace "Buy" label with "x1" on shop purchase buttons to align with other quantity buttons
- Update shop test to expect new label

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e4c5bd0b483238beea04f2e0834d6