### PR TITLE
Raise feedback modal above store overlay

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -396,7 +396,7 @@ body {
   border-radius: 6px;
   font-family: sans-serif;
   display: none;
-  z-index: 10000;
+  z-index: 10002;
   width: 260px;
 }
 #feedbackModal textarea {


### PR DESCRIPTION
## Summary
- raise feedback modal z-index so it isn't hidden behind the store panel

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e677603c883239a2d2f5a4f24945a