### PR TITLE
Expand shop panel and allow tooltip overflow

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -216,13 +216,15 @@ body {
   top: 60px;
   right: 10px;
   bottom: 80px;
-  display: block;
+  width: 360px;
+  display: flex;
+  flex-direction: column;
   background: #222;
   color: #fff;
   padding: 8px;
   border-radius: 6px;
   z-index: 10001;
-  overflow-y: auto;
+  overflow: visible;
 }
 #shopPanel h4 {
   font-size: 2rem; /* makes it roughly 32px tall */
@@ -239,6 +241,11 @@ body {
   gap: 4px;
   padding-bottom: 8px;
   z-index: 1;
+}
+
+#shopItemsContainer {
+  flex: 1;
+  overflow-y: auto;
 }
 
 .upgrade-item {


### PR DESCRIPTION
## Summary
- widen shop panel and restructure layout for flex
- avoid clipping of upgrade tooltips by exposing overflow and using scrollable items container

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0063be2848323886bbb95bbe4ba2c