### PR TITLE
Show first upgrade and add shop dividers

### DIFF
--- a/src/__tests__/shop.test.js
+++ b/src/__tests__/shop.test.js
@@ -307,7 +307,7 @@ describe('shop purchasing flow', () => {
     expect(gameState.globalCount).toBe(190000);
   });
 
-  test('upgrade hidden until requirement met', async () => {
+  test('upgrades hidden until requirement met except first', async () => {
     setupDOM();
     const uid = 'user456';
     const refs = {};
@@ -355,7 +355,9 @@ describe('shop purchasing flow', () => {
     });
     await Promise.resolve();
     await Promise.resolve();
-    const upgEl = document.getElementById('upgrade-upg1');
-    expect(upgEl.classList.contains('hidden')).toBe(true);
+    const upg1El = document.getElementById('upgrade-upg1');
+    const upg2El = document.getElementById('upgrade-upg2');
+    expect(upg1El.classList.contains('hidden')).toBe(false);
+    expect(upg2El.classList.contains('hidden')).toBe(true);
   });
 });

--- a/src/shop.js
+++ b/src/shop.js
@@ -134,9 +134,10 @@ export function initShop({
   });
 
   // Render upgrades bar
-  upgrades.forEach((upg) => {
+  upgrades.forEach((upg, idx) => {
     const div = document.createElement('div');
-    div.className = 'upgrade-item hidden disabled';
+    div.className = 'upgrade-item disabled';
+    if (idx > 0) div.classList.add('hidden');
     div.id = `upgrade-${upg.id}`;
     div.innerHTML = `
       <img src="${upg.image}" alt="${upg.name}">
@@ -188,7 +189,7 @@ export function initShop({
 
     function updateState() {
       const unlocked = (owned[upg.target] || 0) >= (upg.unlockAt || 0);
-      div.classList.toggle('hidden', !unlocked);
+      div.classList.toggle('hidden', !unlocked && idx > 0);
       const affordable =
         unlocked && gameState.globalCount >= upg.cost && !ownedUpgrades[upg.id];
       div.classList.toggle('disabled', !affordable);

--- a/styles/base.css
+++ b/styles/base.css
@@ -231,6 +231,8 @@ body {
   font-weight: bold; /* extra emphasis */
   margin-top: 0;
   margin-bottom: 0.5em;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #444;
 }
 
 #upgradesBar {
@@ -240,6 +242,8 @@ body {
   display: flex;
   gap: 4px;
   padding-bottom: 8px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #444;
   z-index: 1;
 }
 


### PR DESCRIPTION
## Summary
- add visual dividers between shop title, upgrades bar, and items
- keep first upgrade visible while others unlock on requirement
- update tests for upgrade visibility

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0079abbf0832383785316249eaee7