### PR TITLE
Revise item owned display and bump version

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,7 +175,7 @@
       <button id="feedbackSubmit">Send</button>
     </div>
     <div id="discordWrapper">
-      <span id="versionNumber">v0.1.7</span>
+      <span id="versionNumber">v0.1.9</span>
       <button id="feedbackBtn">Feedback</button>
       <a
         id="discordBtn"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gub-gub-site",
-  "version": "0.1.7",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gub-gub-site",
-      "version": "0.1.7",
+      "version": "0.1.9",
       "license": "ISC",
       "devDependencies": {
         "@eslint/create-config": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gub-gub-site",
-  "version": "0.1.7",
+  "version": "0.1.9",
   "description": "For gub the doge",
   "main": "index.js",
   "scripts": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,5 +1,5 @@
 {
   "name": "shared",
-  "version": "0.1.7",
+  "version": "0.1.9",
   "type": "module"
 }

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ import { initErrorLogging } from './errorHandling.js';
 import { initGameLoop } from './gameLoop.js';
 
 window.addEventListener('DOMContentLoaded', () => {
-  const CLIENT_VERSION = '0.1.7';
+  const CLIENT_VERSION = '0.1.9';
   document.getElementById('versionNumber').textContent = `v${CLIENT_VERSION}`;
   const isMobile = window.innerWidth < 768;
   const NUM_FLOATERS = isMobile ? 5 : 20;

--- a/src/shop.js
+++ b/src/shop.js
@@ -217,11 +217,11 @@ export function initShop({
         }<br>
         Cost: <span id="cost-${item.id}"></span> Gubs<br>
         Rate: ${abbreviateNumber(item.rate)} Gub/s<br>
-        Owned: <span id="owned-${item.id}">0</span><br>
         <button id="buy-${item.id}">x1</button>
         <button id="buy-${item.id}-x10">x10</button>
         <button id="buy-${item.id}-x100">x100</button>
       </div>
+      <span id="owned-${item.id}" class="owned-count">0</span>
     `;
     shopContainer.appendChild(div);
     const hr = document.createElement('hr');

--- a/styles/base.css
+++ b/styles/base.css
@@ -320,6 +320,16 @@ body {
   flex-shrink: 0;
 }
 
+#shopItemsContainer .shop-item-details {
+  flex: 1;
+}
+
+#shopItemsContainer .owned-count {
+  margin-left: auto;
+  font-size: 1.5em;
+  font-weight: bold;
+}
+
 #adminPanel {
   position: absolute;
   top: 90px;


### PR DESCRIPTION
## Summary
- Move item owned counts to the right side and display them larger
- Bump project version to 0.1.9 across packages and UI

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0091e58a48323bee33add62ef6060