### PR TITLE
Allow tooltip on disabled upgrade items

### DIFF
--- a/src/shop.js
+++ b/src/shop.js
@@ -150,6 +150,7 @@ export function initShop({
     upgradesContainer.appendChild(div);
 
     async function attemptPurchase() {
+      if (div.classList.contains('disabled')) return;
       if (ownedUpgrades[upg.id]) return;
       if (gameState.globalCount < upg.cost) return;
       playBuySound();

--- a/styles/base.css
+++ b/styles/base.css
@@ -284,7 +284,7 @@ body {
 
 .upgrade-item.disabled {
   opacity: 0.5;
-  pointer-events: none;
+  cursor: not-allowed;
 }
 
 .upgrade-item.disabled img {


### PR DESCRIPTION
## Summary
- show upgrade tooltips even when disabled
- guard against purchasing when upgrade is disabled

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a00d8cfbc08323857ce4a1e112a596