### PR TITLE
Show upgrade cost and fix tooltip opacity

### DIFF
--- a/src/shop.js
+++ b/src/shop.js
@@ -144,6 +144,7 @@ export function initShop({
       <div class="upgrade-tooltip">
         <strong>${upg.name}</strong><br>
         ${upg.modifier}<br>
+        Cost: ${abbreviateNumber(upg.cost)} Gubs<br>
         <span class="desc">${upg.description}</span>
       </div>
     `;

--- a/styles/base.css
+++ b/styles/base.css
@@ -283,12 +283,12 @@ body {
 }
 
 .upgrade-item.disabled {
-  opacity: 0.5;
   cursor: not-allowed;
 }
 
 .upgrade-item.disabled img {
   filter: grayscale(1);
+  opacity: 0.5;
 }
 
 .upgrade-item.owned img {


### PR DESCRIPTION
## Summary
- display upgrade costs in tooltip
- fix disabled upgrade tooltip being dim by only dimming the icon

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a00f3f4b948323abd39093ce1f34c5