### PR TITLE
Show upgrade costs inline with color cues

### DIFF
--- a/src/shop.js
+++ b/src/shop.js
@@ -142,13 +142,17 @@ export function initShop({
     div.innerHTML = `
       <img src="${upg.image}" alt="${upg.name}">
       <div class="upgrade-tooltip">
-        <strong>${upg.name}</strong><br>
+        <strong>${upg.name} <span class="upgrade-cost">${abbreviateNumber(
+          upg.cost,
+        )} Gubs</span></strong><br>
         ${upg.modifier}<br>
-        Cost: ${abbreviateNumber(upg.cost)} Gubs<br>
         <span class="desc">${upg.description}</span>
       </div>
     `;
     upgradesContainer.appendChild(div);
+
+    const costSpan = div.querySelector('.upgrade-cost');
+    if (costSpan) costSpan.style.color = 'red';
 
     async function attemptPurchase() {
       if (div.classList.contains('disabled')) return;
@@ -195,6 +199,7 @@ export function initShop({
       const affordable =
         unlocked && gameState.globalCount >= upg.cost && !ownedUpgrades[upg.id];
       div.classList.toggle('disabled', !affordable);
+      if (costSpan) costSpan.style.color = affordable ? 'green' : 'red';
     }
 
     updateFns.push(updateState);

--- a/styles/base.css
+++ b/styles/base.css
@@ -326,6 +326,11 @@ body {
   color: #ccc;
 }
 
+.upgrade-tooltip .upgrade-cost {
+  font-size: 0.8em;
+  margin-left: 4px;
+}
+
 #shopItemsContainer .shop-item {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Display upgrade costs inline with upgrade names and remove "Cost" label
- Add color-coded cost text that turns green when affordable, red otherwise

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a011469a608323b3b37f8fe941794d