### PR TITLE
Improve upgrade cost display

### DIFF
--- a/src/__tests__/shop.test.js
+++ b/src/__tests__/shop.test.js
@@ -305,6 +305,8 @@ describe('shop purchasing flow', () => {
     expect(purchaseUpgradeFn).toHaveBeenCalledWith({ upgrade: 'upg1' });
     expect(upgEl.classList.contains('owned')).toBe(true);
     expect(gameState.globalCount).toBe(190000);
+    const costSpan = upgEl.querySelector('.upgrade-cost');
+    expect(costSpan.textContent).toBe('Purchased');
   });
 
   test('upgrades hidden until requirement met except first', async () => {

--- a/src/shop.js
+++ b/src/shop.js
@@ -139,12 +139,11 @@ export function initShop({
     div.className = 'upgrade-item disabled';
     if (idx > 0) div.classList.add('hidden');
     div.id = `upgrade-${upg.id}`;
+    const costText = abbreviateNumber(upg.cost);
     div.innerHTML = `
       <img src="${upg.image}" alt="${upg.name}">
       <div class="upgrade-tooltip">
-        <strong>${upg.name} <span class="upgrade-cost">${abbreviateNumber(
-          upg.cost,
-        )} Gubs</span></strong><br>
+        <strong>${upg.name}<span class="upgrade-cost">${costText}</span></strong><br>
         ${upg.modifier}<br>
         <span class="desc">${upg.description}</span>
       </div>
@@ -166,6 +165,10 @@ export function initShop({
           if (res.data.owned) {
             ownedUpgrades[upg.id] = true;
             div.classList.add('owned');
+            if (costSpan) {
+          costSpan.textContent = 'Purchased';
+          costSpan.style.color = 'red';
+            }
           }
           if (typeof res.data.score === 'number') {
             gameState.globalCount = gameState.displayedCount = res.data.score;
@@ -199,7 +202,15 @@ export function initShop({
       const affordable =
         unlocked && gameState.globalCount >= upg.cost && !ownedUpgrades[upg.id];
       div.classList.toggle('disabled', !affordable);
-      if (costSpan) costSpan.style.color = affordable ? 'green' : 'red';
+      if (costSpan) {
+        if (ownedUpgrades[upg.id]) {
+          costSpan.style.color = 'red';
+          costSpan.textContent = 'Purchased';
+        } else {
+          costSpan.style.color = affordable ? 'green' : 'red';
+          costSpan.textContent = costText;
+        }
+      }
     }
 
     updateFns.push(updateState);
@@ -356,7 +367,14 @@ export function initShop({
         if (upgStored[upg.id]) {
           ownedUpgrades[upg.id] = true;
           const div = document.getElementById(`upgrade-${upg.id}`);
-          if (div) div.classList.add('owned');
+          if (div) {
+            div.classList.add('owned');
+            const costSpan = div.querySelector('.upgrade-cost');
+            if (costSpan) {
+              costSpan.textContent = 'Purchased';
+              costSpan.style.color = 'red';
+            }
+          }
         }
       });
       updatePassiveIncome();

--- a/styles/base.css
+++ b/styles/base.css
@@ -326,9 +326,13 @@ body {
   color: #ccc;
 }
 
+.upgrade-tooltip strong {
+  display: flex;
+}
+
 .upgrade-tooltip .upgrade-cost {
   font-size: 0.8em;
-  margin-left: 4px;
+  margin-left: auto;
 }
 
 #shopItemsContainer .shop-item {


### PR DESCRIPTION
## Summary
- remove "Gubs" text from upgrade tooltips and align cost to the right
- show "Purchased" in red for owned upgrades
- test that purchased upgrades show the new label

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a01379bccc83238a27dee5c3ab78b9