### PR TITLE
Warm up purchase functions to reduce cold start lag

### DIFF
--- a/functions/__tests__/validation.test.js
+++ b/functions/__tests__/validation.test.js
@@ -14,6 +14,7 @@ jest.unstable_mockModule('firebase-functions', () => ({
 const {
   validateSyncGubs,
   validatePurchaseItem,
+  validatePurchaseUpgrade,
   validateUsername,
   validateAdminUpdate,
   validateAdminDelete,
@@ -39,14 +40,29 @@ describe('validation utilities', () => {
   });
 
   test('validatePurchaseItem validates item and quantity', () => {
-    expect(validatePurchaseItem({ item: 'passiveMaker', quantity: 2 })).toEqual(
-      {
-        item: 'passiveMaker',
-        quantity: 2,
-      },
-    );
+    expect(validatePurchaseItem({ item: 'passiveMaker', quantity: 2 })).toEqual({
+      item: 'passiveMaker',
+      quantity: 2,
+      dryRun: false,
+    });
+    expect(
+      validatePurchaseItem({ item: 'passiveMaker', dryRun: true }),
+    ).toEqual({ item: 'passiveMaker', quantity: 1, dryRun: true });
     expect(() => validatePurchaseItem({ item: 'nope', quantity: 1 })).toThrow(
       'Unknown item',
+    );
+  });
+
+  test('validatePurchaseUpgrade handles dryRun', () => {
+    expect(validatePurchaseUpgrade({ upgrade: 'upg1' })).toEqual({
+      upgrade: 'upg1',
+      dryRun: false,
+    });
+    expect(
+      validatePurchaseUpgrade({ upgrade: 'upg1', dryRun: true }),
+    ).toEqual({ upgrade: 'upg1', dryRun: true });
+    expect(() => validatePurchaseUpgrade({ upgrade: 'nope' })).toThrow(
+      'Unknown upgrade',
     );
   });
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -138,7 +138,10 @@ export const purchaseItem = functions.https.onCall(
   withAuth(async (uid, data) => {
     return withUserLock(uid, 'purchaseItem', async () => {
       try {
-        const { item, quantity } = validatePurchaseItem(data);
+        const { item, quantity, dryRun } = validatePurchaseItem(data);
+        if (dryRun) {
+          return { ok: true };
+        }
         const db = admin.database();
 
         const scoreRef = db.ref(`${LEADERBOARD_PATH}/${uid}/score`);
@@ -215,7 +218,10 @@ export const purchaseUpgrade = functions.https.onCall(
   withAuth(async (uid, data) => {
     return withUserLock(uid, 'purchaseUpgrade', async () => {
       try {
-        const { upgrade } = validatePurchaseUpgrade(data);
+        const { upgrade, dryRun } = validatePurchaseUpgrade(data);
+        if (dryRun) {
+          return { ok: true };
+        }
         const db = admin.database();
 
         const scoreRef = db.ref(`${LEADERBOARD_PATH}/${uid}/score`);

--- a/functions/validation.js
+++ b/functions/validation.js
@@ -18,6 +18,7 @@ export function validateSyncGubs(data = {}) {
 
 export function validatePurchaseItem(data = {}) {
   const item = data.item;
+  const dryRun = Boolean(data.dryRun);
   if (!SHOP_ITEMS[item]) {
     throw new functions.https.HttpsError('invalid-argument', 'Unknown item');
   }
@@ -30,21 +31,22 @@ export function validatePurchaseItem(data = {}) {
     );
   }
   const quantity = Math.floor(numQuantity);
-  if (quantity < 1 || quantity > 1000) {
+  if (quantity < 0 || quantity > 1000 || (!dryRun && quantity < 1)) {
     throw new functions.https.HttpsError(
       'invalid-argument',
       'Quantity must be between 1 and 1000',
     );
   }
-  return { item, quantity };
+  return { item, quantity, dryRun };
 }
 
 export function validatePurchaseUpgrade(data = {}) {
   const upgrade = data.upgrade;
-  if (!UPGRADES[upgrade]) {
+  const dryRun = Boolean(data.dryRun);
+  if (!UPGRADES[upgrade] && !dryRun) {
     throw new functions.https.HttpsError('invalid-argument', 'Unknown upgrade');
   }
-  return { upgrade };
+  return { upgrade, dryRun };
 }
 
 export function validateUsername(rawUsername) {

--- a/src/shop.js
+++ b/src/shop.js
@@ -50,6 +50,23 @@ export function initShop({
   };
   const ownedUpgrades = {};
 
+  // Warm cloud functions to avoid cold-start delay on first purchase
+  function warmupPurchases() {
+    if (shopItems[0]) {
+      Promise.resolve(
+        purchaseItemFn({ item: shopItems[0].id, dryRun: true }),
+      ).catch(() => {});
+    }
+    if (upgrades[0]) {
+      Promise.resolve(
+        purchaseUpgradeFn({ upgrade: upgrades[0].id, dryRun: true }),
+      ).catch(() => {});
+    }
+  }
+  warmupPurchases();
+  const warmInterval = setInterval(warmupPurchases, 5 * 60 * 1000);
+  if (warmInterval && typeof warmInterval.unref === 'function') warmInterval.unref();
+
   function updatePassiveIncome() {
     const perSecondTotal = shopItems.reduce((sum, item) => {
       let rate = item.rate;


### PR DESCRIPTION
## Summary
- allow `purchaseItem` and `purchaseUpgrade` to accept a `dryRun` flag
- call purchase endpoints in dry-run mode to warm them and keep subsequent buys snappy

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a01a66232483239288c6b518475a84