### PR TITLE
Add draggable Twitch stream and embedded chat

### DIFF
--- a/functions/__tests__/validation.test.js
+++ b/functions/__tests__/validation.test.js
@@ -40,11 +40,13 @@ describe('validation utilities', () => {
   });
 
   test('validatePurchaseItem validates item and quantity', () => {
-    expect(validatePurchaseItem({ item: 'passiveMaker', quantity: 2 })).toEqual({
-      item: 'passiveMaker',
-      quantity: 2,
-      dryRun: false,
-    });
+    expect(validatePurchaseItem({ item: 'passiveMaker', quantity: 2 })).toEqual(
+      {
+        item: 'passiveMaker',
+        quantity: 2,
+        dryRun: false,
+      },
+    );
     expect(
       validatePurchaseItem({ item: 'passiveMaker', dryRun: true }),
     ).toEqual({ item: 'passiveMaker', quantity: 1, dryRun: true });
@@ -58,9 +60,10 @@ describe('validation utilities', () => {
       upgrade: 'upg1',
       dryRun: false,
     });
-    expect(
-      validatePurchaseUpgrade({ upgrade: 'upg1', dryRun: true }),
-    ).toEqual({ upgrade: 'upg1', dryRun: true });
+    expect(validatePurchaseUpgrade({ upgrade: 'upg1', dryRun: true })).toEqual({
+      upgrade: 'upg1',
+      dryRun: true,
+    });
     expect(() => validatePurchaseUpgrade({ upgrade: 'nope' })).toThrow(
       'Unknown upgrade',
     );

--- a/index.html
+++ b/index.html
@@ -119,20 +119,23 @@
     <div id="bottom-ui">
       <div id="leaderboard"><strong>Leaderboard</strong><br />Loading…</div>
       <div id="chat-row">
-        <div id="chat">
-          <div id="chatResizeHandle"></div>
-          <div id="messages"></div>
-          <div id="mentionSuggestions"></div>
-          <form id="chatForm">
-            <input
-              id="chatInput"
-              type="text"
-              placeholder="Type a message…"
-              autocomplete="off"
-              maxlength="200"
-            />
-            <button type="submit">Send</button>
-          </form>
+        <div id="chats">
+          <div id="chat">
+            <div id="chatResizeHandle"></div>
+            <div id="messages"></div>
+            <div id="mentionSuggestions"></div>
+            <form id="chatForm">
+              <input
+                id="chatInput"
+                type="text"
+                placeholder="Type a message…"
+                autocomplete="off"
+                maxlength="200"
+              />
+              <button type="submit">Send</button>
+            </form>
+          </div>
+          <div id="twitchChat"></div>
         </div>
         <div id="online-users">Online: …</div>
       </div>

--- a/src/__tests__/twitchEmbed.test.js
+++ b/src/__tests__/twitchEmbed.test.js
@@ -1,0 +1,32 @@
+/**
+ * @jest-environment jsdom
+ */
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import { initTwitchEmbed } from '../twitchEmbed.js';
+
+describe('twitch embed position persistence', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <button id="twitchBtn"></button>
+      <div id="twitchPlayer"></div>
+    `;
+    const Embed = function () {
+      return {
+        addEventListener: () => {},
+        getPlayer: () => ({ setMuted: () => {} }),
+      };
+    };
+    Embed.VIDEO_READY = 'ready';
+    global.Twitch = { Embed };
+    localStorage.clear();
+  });
+
+  test('restores saved position', () => {
+    localStorage.setItem('twitchPlayerTop', '50px');
+    localStorage.setItem('twitchPlayerLeft', '100px');
+    initTwitchEmbed();
+    const box = document.getElementById('twitchPlayer');
+    expect(box.style.top).toBe('50px');
+    expect(box.style.left).toBe('100px');
+  });
+});

--- a/src/twitchEmbed.js
+++ b/src/twitchEmbed.js
@@ -3,6 +3,41 @@ export function initTwitchEmbed() {
   const twitchBox = document.getElementById('twitchPlayer');
   twitchBox.style.display = 'block';
   twitchBox.style.visibility = 'hidden';
+
+  // restore saved position or default to top-right
+  const savedTop = localStorage.getItem('twitchPlayerTop');
+  const savedLeft = localStorage.getItem('twitchPlayerLeft');
+  twitchBox.style.top = savedTop || '0px';
+  twitchBox.style.left =
+    savedLeft || `${window.innerWidth - twitchBox.offsetWidth - 10}px`;
+
+  // make the player draggable and persist position
+  let dragOffsetX = 0;
+  let dragOffsetY = 0;
+  let dragging = false;
+
+  twitchBox.addEventListener('mousedown', (e) => {
+    dragging = true;
+    dragOffsetX = e.clientX - twitchBox.offsetLeft;
+    dragOffsetY = e.clientY - twitchBox.offsetTop;
+    e.preventDefault();
+  });
+
+  document.addEventListener('mousemove', (e) => {
+    if (!dragging) return;
+    const left = e.clientX - dragOffsetX;
+    const top = e.clientY - dragOffsetY;
+    twitchBox.style.left = `${left}px`;
+    twitchBox.style.top = `${top}px`;
+  });
+
+  document.addEventListener('mouseup', () => {
+    if (!dragging) return;
+    dragging = false;
+    localStorage.setItem('twitchPlayerLeft', twitchBox.style.left);
+    localStorage.setItem('twitchPlayerTop', twitchBox.style.top);
+  });
+
   const twitchEmbed = new Twitch.Embed('twitchPlayer', {
     width: '100%',
     height: '100%',
@@ -18,6 +53,16 @@ export function initTwitchEmbed() {
     twitchPlayer.setMuted(true);
   });
   let twitchShown = false;
+
+  // load standalone twitch chat if container exists
+  const twitchChatBox = document.getElementById('twitchChat');
+  if (twitchChatBox) {
+    const chatFrame = document.createElement('iframe');
+    chatFrame.src = `https://www.twitch.tv/embed/harupi/chat?parent=${location.hostname}`;
+    chatFrame.setAttribute('frameborder', '0');
+    chatFrame.setAttribute('scrolling', 'no');
+    twitchChatBox.appendChild(chatFrame);
+  }
 
   function toggle() {
     if (!twitchShown) {
@@ -36,4 +81,3 @@ export function initTwitchEmbed() {
 
   return { toggle };
 }
-

--- a/styles/base.css
+++ b/styles/base.css
@@ -418,6 +418,25 @@ body {
   align-items: flex-start;
 }
 
+#chats {
+  display: flex;
+  gap: 6px;
+  align-items: flex-start;
+}
+
+#twitchChat {
+  width: 350px;
+  height: 240px;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+#twitchChat iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
 #online-users {
   background: rgba(0, 0, 0, 0.6);
   color: #fff;
@@ -429,7 +448,7 @@ body {
 #twitchPlayer {
   position: absolute;
   top: 0;
-  right: 10px;
+  left: calc(100vw - 510px);
   width: 500px;
   height: 300px;
   z-index: 20000;
@@ -438,6 +457,7 @@ body {
   border: 2px solid rgba(255, 255, 255, 0.1);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
   border-radius: 8px;
+  cursor: move;
 }
 #golden-counter {
   position: absolute;


### PR DESCRIPTION
## Summary
- Allow Twitch stream player to be dragged and persist its position in localStorage
- Embed Twitch chat beside the in-site chat with new layout and styles
- Verify stream position persistence with dedicated unit test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a02021b10483238187053793f1a5d4