### PR TITLE
Add basic dress-up game

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 For gub the doge
 
+## Dress Up
+
+Try the simple dress-up game at [gub.cam/dress-up](https://gub.cam/dress-up).
+
 ## Error logging
 
 Client-side errors and Cloud Function exceptions are stored in the Firebase

--- a/dress-up/index.html
+++ b/dress-up/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gub Dress Up</title>
+    <link rel="stylesheet" href="../styles/base.css" />
+    <link rel="stylesheet" href="../styles/dress-up.css" />
+  </head>
+  <body>
+    <h1>Dress Up Gub</h1>
+    <div id="game">
+      <div id="character">
+        <img id="base" src="../gub_wicked.png" alt="gub" />
+        <img id="hat" class="layer" alt="hat" />
+        <img id="tie" class="layer" alt="tie" />
+        <img id="shoes" class="layer" alt="shoes" />
+        <img id="accessory" class="layer" alt="accessory" />
+      </div>
+      <div class="controls">
+        <div class="control" data-layer="hat">
+          <button class="prev">Prev Hat</button>
+          <button class="next">Next Hat</button>
+        </div>
+        <div class="control" data-layer="tie">
+          <button class="prev">Prev Tie</button>
+          <button class="next">Next Tie</button>
+        </div>
+        <div class="control" data-layer="shoes">
+          <button class="prev">Prev Shoes</button>
+          <button class="next">Next Shoes</button>
+        </div>
+        <div class="control" data-layer="accessory">
+          <button class="prev">Prev Accessory</button>
+          <button class="next">Next Accessory</button>
+        </div>
+      </div>
+      <button id="download">Download Outfit</button>
+    </div>
+    <script type="module" src="../src/dress-up.js"></script>
+  </body>
+</html>

--- a/src/dress-up.js
+++ b/src/dress-up.js
@@ -1,0 +1,79 @@
+const layers = {
+  hat: {
+    options: [
+      '../small_gub_01_gluburple.png',
+      '../small_gub_02_Glurp.png',
+      '../small_gub_03_Gorpa.png'
+    ],
+    index: 0,
+    element: document.getElementById('hat')
+  },
+  tie: {
+    options: [
+      '../small_gub_04_GubsUp.png',
+      '../small_gub_05_GubShy.png',
+      '../small_gub_06_GubsComfy.png'
+    ],
+    index: 0,
+    element: document.getElementById('tie')
+  },
+  shoes: {
+    options: [
+      '../small_gub_07_gubpoint.png',
+      '../small_gub_08_gubmote1.png',
+      '../small_gub_09_gubgub.png'
+    ],
+    index: 0,
+    element: document.getElementById('shoes')
+  },
+  accessory: {
+    options: [
+      '../small_gub_10_gubfinger.png',
+      '../small_gub_11_Grizz.png'
+    ],
+    index: 0,
+    element: document.getElementById('accessory')
+  }
+};
+
+function updateLayer(name) {
+  const layer = layers[name];
+  if (layer.options.length) {
+    layer.element.src = layer.options[layer.index];
+  }
+}
+
+Object.keys(layers).forEach(updateLayer);
+
+document.querySelectorAll('.control').forEach((ctrl) => {
+  const name = ctrl.dataset.layer;
+  ctrl.querySelector('.prev').addEventListener('click', () => {
+    const layer = layers[name];
+    layer.index = (layer.index - 1 + layer.options.length) % layer.options.length;
+    updateLayer(name);
+  });
+  ctrl.querySelector('.next').addEventListener('click', () => {
+    const layer = layers[name];
+    layer.index = (layer.index + 1) % layer.options.length;
+    updateLayer(name);
+  });
+});
+
+document.getElementById('download').addEventListener('click', () => {
+  const base = document.getElementById('base');
+  const canvas = document.createElement('canvas');
+  canvas.width = base.naturalWidth;
+  canvas.height = base.naturalHeight;
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(base, 0, 0);
+  ['hat', 'tie', 'shoes', 'accessory'].forEach((id) => {
+    const img = document.getElementById(id);
+    if (img && img.src) {
+      ctx.drawImage(img, 0, 0);
+    }
+  });
+  const link = document.createElement('a');
+  link.download = 'gub-dress-up.png';
+  link.href = canvas.toDataURL();
+  link.click();
+});

--- a/styles/dress-up.css
+++ b/styles/dress-up.css
@@ -1,0 +1,38 @@
+#game {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  color: #fff;
+}
+
+#character {
+  position: relative;
+  width: 300px;
+  height: 300px;
+}
+
+#character img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+#character img#base {
+  position: relative;
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.control {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+}


### PR DESCRIPTION
## Summary
- Add `/dress-up` page with basic Gub dress-up functionality
- Implement JavaScript to cycle hats, ties, shoes, and accessories and export final image
- Document new mini-game in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a57026f9d08323a68b14632de55ec7