### PR TITLE
Enlarge dress-up game and limit draggable items

### DIFF
--- a/dress-up/index.html
+++ b/dress-up/index.html
@@ -13,7 +13,12 @@
         <img src="../head_01.png" alt="hat" class="asset" draggable="true" />
       </div>
       <div id="character">
-        <img id="base" src="../Main_Dress_Gub.png" alt="gub" />
+        <img
+          id="base"
+          src="../Main_Dress_Gub.png"
+          alt="gub"
+          draggable="false"
+        />
       </div>
       <button id="download">Download Outfit</button>
     </div>

--- a/src/dress-up.js
+++ b/src/dress-up.js
@@ -28,7 +28,12 @@ function makeDraggable(el) {
 
 document.querySelectorAll('#assets img').forEach((asset) => {
   asset.addEventListener('dragstart', (e) => {
+    if (asset.dataset.used === 'true') {
+      e.preventDefault();
+      return;
+    }
     e.dataTransfer.setData('text/plain', asset.src);
+    e.dataTransfer.setDragImage(asset, asset.width / 2, asset.height / 2);
   });
 });
 
@@ -40,6 +45,7 @@ character.addEventListener('drop', (e) => {
   e.preventDefault();
   const src = e.dataTransfer.getData('text/plain');
   if (!src) return;
+  if (character.querySelector(`img.layer[src="${src}"]`)) return;
 
   const img = document.createElement('img');
   img.src = src;
@@ -57,6 +63,13 @@ character.addEventListener('drop', (e) => {
 
   makeDraggable(img);
   character.appendChild(img);
+
+  const asset = document.querySelector(`#assets img[src="${src}"]`);
+  if (asset) {
+    asset.dataset.used = 'true';
+    asset.style.opacity = '0.5';
+    asset.draggable = false;
+  }
 });
 
 document.getElementById('download').addEventListener('click', () => {

--- a/styles/dress-up.css
+++ b/styles/dress-up.css
@@ -17,7 +17,7 @@
 }
 
 #assets img {
-  width: 80px;
+  width: 580px;
   cursor: grab;
 }
 
@@ -26,8 +26,8 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 300px;
-  height: 300px;
+  width: 800px;
+  height: 800px;
 }
 
 #character img {
@@ -41,6 +41,7 @@
 
 #character img#base {
   position: relative;
+  pointer-events: none;
 }
 
 #download {


### PR DESCRIPTION
## Summary
- Expand dress-up canvas and asset thumbnails by 500px for better visibility
- Prevent main gub from being dragged and only allow one of each asset to be placed
- Provide proper drag previews and disable assets after use

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a57680088c83239491996b5dc8b734