### PR TITLE
Revert dress-up asset enlargement and drag originals

### DIFF
--- a/dress-up/index.html
+++ b/dress-up/index.html
@@ -10,7 +10,7 @@
   <body>
     <div id="game">
       <div id="assets">
-        <img src="../head_01.png" alt="hat" class="asset" draggable="true" />
+        <img src="../head_01.png" alt="hat" class="asset" draggable="false" />
       </div>
       <div id="character">
         <img

--- a/src/dress-up.js
+++ b/src/dress-up.js
@@ -2,14 +2,21 @@ const character = document.getElementById('character');
 
 function makeDraggable(el) {
   el.addEventListener('mousedown', (e) => {
-    const shiftX = e.clientX - el.getBoundingClientRect().left;
-    const shiftY = e.clientY - el.getBoundingClientRect().top;
+    const rect = el.getBoundingClientRect();
+    const shiftX = e.clientX - rect.left;
+    const shiftY = e.clientY - rect.top;
+
+    if (el.parentElement !== character) {
+      character.appendChild(el);
+    }
 
     function moveAt(clientX, clientY) {
-      const rect = character.getBoundingClientRect();
-      el.style.left = `${clientX - rect.left - shiftX}px`;
-      el.style.top = `${clientY - rect.top - shiftY}px`;
+      const characterRect = character.getBoundingClientRect();
+      el.style.left = `${clientX - characterRect.left - shiftX}px`;
+      el.style.top = `${clientY - characterRect.top - shiftY}px`;
     }
+
+    moveAt(e.clientX, e.clientY);
 
     function onMouseMove(event) {
       moveAt(event.clientX, event.clientY);
@@ -21,55 +28,13 @@ function makeDraggable(el) {
       () => {
         document.removeEventListener('mousemove', onMouseMove);
       },
-      { once: true }
+      { once: true },
     );
   });
 }
-
 document.querySelectorAll('#assets img').forEach((asset) => {
-  asset.addEventListener('dragstart', (e) => {
-    if (asset.dataset.used === 'true') {
-      e.preventDefault();
-      return;
-    }
-    e.dataTransfer.setData('text/plain', asset.src);
-    e.dataTransfer.setDragImage(asset, asset.width / 2, asset.height / 2);
-  });
-});
-
-character.addEventListener('dragover', (e) => {
-  e.preventDefault();
-});
-
-character.addEventListener('drop', (e) => {
-  e.preventDefault();
-  const src = e.dataTransfer.getData('text/plain');
-  if (!src) return;
-  if (character.querySelector(`img.layer[src="${src}"]`)) return;
-
-  const img = document.createElement('img');
-  img.src = src;
-  img.className = 'layer';
-  img.draggable = false;
-
-  const rect = character.getBoundingClientRect();
-  const x = e.clientX - rect.left;
-  const y = e.clientY - rect.top;
-
-  img.addEventListener('load', () => {
-    img.style.left = `${x - img.width / 2}px`;
-    img.style.top = `${y - img.height / 2}px`;
-  });
-
-  makeDraggable(img);
-  character.appendChild(img);
-
-  const asset = document.querySelector(`#assets img[src="${src}"]`);
-  if (asset) {
-    asset.dataset.used = 'true';
-    asset.style.opacity = '0.5';
-    asset.draggable = false;
-  }
+  asset.draggable = false;
+  makeDraggable(asset);
 });
 
 document.getElementById('download').addEventListener('click', () => {
@@ -79,7 +44,7 @@ document.getElementById('download').addEventListener('click', () => {
   canvas.height = base.naturalHeight;
   const ctx = canvas.getContext('2d');
   ctx.drawImage(base, 0, 0);
-  document.querySelectorAll('#character .layer').forEach((img) => {
+  document.querySelectorAll('#character img:not(#base)').forEach((img) => {
     const x = parseFloat(img.style.left) || 0;
     const y = parseFloat(img.style.top) || 0;
     ctx.drawImage(img, x, y);
@@ -89,4 +54,3 @@ document.getElementById('download').addEventListener('click', () => {
   link.href = canvas.toDataURL();
   link.click();
 });
-

--- a/styles/dress-up.css
+++ b/styles/dress-up.css
@@ -17,7 +17,7 @@
 }
 
 #assets img {
-  width: 580px;
+  width: 80px;
   cursor: grab;
 }
 
@@ -26,8 +26,8 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 800px;
-  height: 800px;
+  width: 300px;
+  height: 300px;
 }
 
 #character img {
@@ -51,6 +51,6 @@
   transform: translateX(-50%);
 }
 
-.layer {
+#character img:not(#base) {
   cursor: grab;
 }


### PR DESCRIPTION
## Summary
- Restore original dress-up canvas and asset sizing
- Allow dragging of original asset from sidebar instead of creating a copy

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a578c63d208323969ce7c0bde048ca