### PR TITLE
Fix asset scaling in drag-and-drop dress-up

### DIFF
--- a/styles/dress-up.css
+++ b/styles/dress-up.css
@@ -34,14 +34,14 @@
   position: absolute;
   top: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
   object-fit: contain;
 }
 
 #character img#base {
   position: relative;
   pointer-events: none;
+  width: 100%;
+  height: 100%;
 }
 
 #download {
@@ -53,4 +53,6 @@
 
 #character img:not(#base) {
   cursor: grab;
+  width: 80px;
+  height: auto;
 }


### PR DESCRIPTION
## Summary
- prevent dress-up assets from scaling to full character size when dragged

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a57b4c935c8323a0bba682bd9e10c9