### PR TITLE
fix: preserve asset size and placement when downloading

### DIFF
--- a/src/dress-up.js
+++ b/src/dress-up.js
@@ -43,11 +43,13 @@ document.getElementById('download').addEventListener('click', () => {
   canvas.width = base.naturalWidth;
   canvas.height = base.naturalHeight;
   const ctx = canvas.getContext('2d');
-  ctx.drawImage(base, 0, 0);
+  const scaleX = base.naturalWidth / base.width;
+  const scaleY = base.naturalHeight / base.height;
+  ctx.drawImage(base, 0, 0, base.naturalWidth, base.naturalHeight);
   document.querySelectorAll('#character img:not(#base)').forEach((img) => {
-    const x = parseFloat(img.style.left) || 0;
-    const y = parseFloat(img.style.top) || 0;
-    ctx.drawImage(img, x, y);
+    const x = (parseFloat(img.style.left) || 0) * scaleX;
+    const y = (parseFloat(img.style.top) || 0) * scaleY;
+    ctx.drawImage(img, x, y, img.naturalWidth, img.naturalHeight);
   });
   const link = document.createElement('a');
   link.download = 'gub-dress-up.png';


### PR DESCRIPTION
## Summary
- ensure download canvas keeps character assets at their original resolution
- scale asset coordinates to match the base image size

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a57cf689048323b9d58ec8a28ec511