### PR TITLE
fix: maintain asset scale in dress up

### DIFF
--- a/src/dress-up.js
+++ b/src/dress-up.js
@@ -1,13 +1,20 @@
 const character = document.getElementById('character');
+const base = document.getElementById('base');
 
 function makeDraggable(el) {
   el.addEventListener('mousedown', (e) => {
-    const rect = el.getBoundingClientRect();
-    const shiftX = e.clientX - rect.left;
-    const shiftY = e.clientY - rect.top;
+    let rect = el.getBoundingClientRect();
+    let shiftX = e.clientX - rect.left;
+    let shiftY = e.clientY - rect.top;
 
     if (el.parentElement !== character) {
       character.appendChild(el);
+      const scale = base.width / base.naturalWidth;
+      el.style.width = `${el.naturalWidth * scale}px`;
+      el.style.height = `${el.naturalHeight * scale}px`;
+      rect = el.getBoundingClientRect();
+      shiftX = e.clientX - rect.left;
+      shiftY = e.clientY - rect.top;
     }
 
     function moveAt(clientX, clientY) {
@@ -38,7 +45,6 @@ document.querySelectorAll('#assets img').forEach((asset) => {
 });
 
 document.getElementById('download').addEventListener('click', () => {
-  const base = document.getElementById('base');
   const canvas = document.createElement('canvas');
   canvas.width = base.naturalWidth;
   canvas.height = base.naturalHeight;

--- a/styles/dress-up.css
+++ b/styles/dress-up.css
@@ -53,6 +53,4 @@
 
 #character img:not(#base) {
   cursor: grab;
-  width: 80px;
-  height: auto;
 }


### PR DESCRIPTION
## Summary
- preserve natural hat size when dragging onto character
- remove hardcoded character asset sizing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a57f0d70508323957de17556fef7b3