### PR TITLE
Fix dress-up asset jump during drag

### DIFF
--- a/src/dress-up.js
+++ b/src/dress-up.js
@@ -3,18 +3,18 @@ const base = document.getElementById('base');
 
 function makeDraggable(el) {
   el.addEventListener('mousedown', (e) => {
-    let rect = el.getBoundingClientRect();
-    let shiftX = e.clientX - rect.left;
-    let shiftY = e.clientY - rect.top;
+    const rect = el.getBoundingClientRect();
+    const shiftX = e.clientX - rect.left;
+    const shiftY = e.clientY - rect.top;
 
     if (el.parentElement !== character) {
       character.appendChild(el);
       const scale = base.width / base.naturalWidth;
       el.style.width = `${el.naturalWidth * scale}px`;
       el.style.height = `${el.naturalHeight * scale}px`;
-      rect = el.getBoundingClientRect();
-      shiftX = e.clientX - rect.left;
-      shiftY = e.clientY - rect.top;
+      const characterRect = character.getBoundingClientRect();
+      el.style.left = `${rect.left - characterRect.left}px`;
+      el.style.top = `${rect.top - characterRect.top}px`;
     }
 
     function moveAt(clientX, clientY) {


### PR DESCRIPTION
## Summary
- Keep dress-up assets at their original screen position when starting a drag
- Position assets relative to character using initial bounding rectangle

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5817c832c8323ab1da1e808594f45