### PR TITLE
fix: correct asset position in downloaded outfit

### DIFF
--- a/src/dress-up.js
+++ b/src/dress-up.js
@@ -55,7 +55,9 @@ document.getElementById('download').addEventListener('click', () => {
   document.querySelectorAll('#character img:not(#base)').forEach((img) => {
     const x = (parseFloat(img.style.left) || 0) * scaleX;
     const y = (parseFloat(img.style.top) || 0) * scaleY;
-    ctx.drawImage(img, x, y, img.naturalWidth, img.naturalHeight);
+    const width = img.width * scaleX;
+    const height = img.height * scaleY;
+    ctx.drawImage(img, x, y, width, height);
   });
   const link = document.createElement('a');
   link.download = 'gub-dress-up.png';


### PR DESCRIPTION
## Summary
- fix downloaded outfit render positions by scaling asset dimensions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a583306d1883238c8ed3aeae6864ec